### PR TITLE
Migrate Zulip secrets to environment-based config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,16 @@
-# Reserved for staging bootstrap.
-# The plugin currently reads Zulip/OpenClaw credentials from the host runtime config/env.
-# Keep secrets out of the repository.
+# Zulip Bridge Configuration — Environment Variables
+# These variables take precedence over any values stored in the configuration file.
+# Only applicable for the default account.
+
+# Zulip bot email address.
+# ZULIP_EMAIL=bot-name@zulipchat.com
+
+# Zulip API key for the bot.
+# ZULIP_API_KEY=your-api-key-here
+
+# Base URL for the Zulip server (e.g., https://chat.zulip.org).
+# ZULIP_URL=https://chat.example.com
+
+# Alternate names for ZULIP_URL.
+# ZULIP_SITE=https://chat.example.com
+# ZULIP_REALM=https://chat.example.com

--- a/README.md
+++ b/README.md
@@ -31,6 +31,17 @@ A GitHub Actions workflow is included at `.github/workflows/ci.yml` and runs `np
 - `docs/` — audit and fix notes
 - `test/fixtures/` — reserved for inbound regression fixtures
 
+## Configuration
+This bridge supports environment-based configuration for Zulip secrets. This is the recommended approach for staging and production environments to avoid plaintext credential storage in the repository or main configuration files.
+
+The following environment variables are supported for the **default account**:
+- `ZULIP_API_KEY`: Zulip API key for the bot.
+- `ZULIP_EMAIL`: Zulip bot email address.
+- `ZULIP_URL` (or `ZULIP_SITE`, `ZULIP_REALM`): Base URL for the Zulip server.
+
+Environment variables take precedence over configuration file fields for the default account. Non-default accounts must be configured via the configuration file.
+
+See [docs/config.md](docs/config.md) for more details.
+
 ## Notes
-- Secrets are still sourced by OpenClaw runtime config/env outside this repo.
 - This bootstrap is intended for staging validation before any production cutover.

--- a/docs/config.md
+++ b/docs/config.md
@@ -1,0 +1,70 @@
+# Zulip Bridge Configuration
+
+The OpenClaw Zulip Bridge can be configured using environment variables or the standard OpenClaw configuration file. Environment variables are recommended for sensitive information (secrets).
+
+## Environment-Based Secrets (Recommended)
+
+To improve security and follow the "secrets-out-of-the-repo" policy, use environment variables for the bot's credentials. This is currently supported for the **default account**.
+
+### Supported Variables
+| Variable | Description |
+| --- | --- |
+| `ZULIP_API_KEY` | The API key for your Zulip bot. |
+| `ZULIP_EMAIL` | The email address associated with your Zulip bot. |
+| `ZULIP_URL` | The base URL of your Zulip server (e.g., `https://chat.example.com`). |
+| `ZULIP_SITE` | Alias for `ZULIP_URL`. |
+| `ZULIP_REALM` | Alias for `ZULIP_URL`. |
+
+### Precedence
+For the **default account**, environment variables **always take precedence** over fields in the configuration file. This ensures that you can override hardcoded (or placeholder) values during staging or production by simply setting the corresponding environment variable.
+
+## Configuration File Setup
+
+If you need to configure multiple Zulip accounts or other settings (like streams, DM policy, etc.), you can use the `channels.zulip` section in your OpenClaw configuration file.
+
+### Default Account
+```json
+{
+  "channels": {
+    "zulip": {
+      "enabled": true,
+      "streams": ["bot-testing", "announcements"],
+      "dmPolicy": "pairing"
+    }
+  }
+}
+```
+
+### Multi-Account Setup
+Non-default accounts must be defined in the `accounts` map and **require** credentials in the configuration file. To prevent accidental secret leakage and ensure predictable behavior, non-default accounts **do not support** environment-based resolution or fallbacks.
+
+```json
+{
+  "channels": {
+    "zulip": {
+      "enabled": true,
+      "accounts": {
+        "production": {
+          "enabled": true,
+          "apiKey": "PROD_API_KEY",
+          "email": "prod-bot@example.com",
+          "url": "https://chat.example.com",
+          "streams": ["*"]
+        },
+        "staging": {
+          "enabled": true,
+          "apiKey": "STAGING_API_KEY",
+          "email": "staging-bot@example.com",
+          "url": "https://staging.example.com"
+        }
+      }
+    }
+  }
+}
+```
+
+## Security Best Practices
+- **Do not commit secrets** to your repository. Use `.env.example` as a template for your local or server environment.
+- **Prefer environment variables** for the default account's `apiKey`.
+- If using multi-account config, ensure your configuration file is properly protected and not part of the source control.
+- Use the least-privileged bot type in Zulip where possible.

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "scripts": {
     "typecheck": "tsc -p tsconfig.json",
     "build": "tsc -p tsconfig.build.json",
-    "test": "node --test --experimental-strip-types test/*.test.ts",
+    "test": "node --test --experimental-strip-types --loader ./test-loader.js test/*.test.ts",
     "check": "npm run typecheck && npm run test && npm run build"
   },
   "peerDependencies": {

--- a/src/zulip/accounts.ts
+++ b/src/zulip/accounts.ts
@@ -112,18 +112,37 @@ export function resolveZulipAccount(params: {
     baseConfig.site ??
     baseConfig.realm;
   const configUrlTrimmed = configUrl?.trim();
-  const apiKey = configApiKey || envApiKey;
-  const email = configEmail || envEmail;
-  const baseUrl = normalizeZulipBaseUrl(configUrlTrimmed || envUrl || envSite || envRealm);
-  const requireMention = resolveZulipRequireMention(merged);
 
-  const apiKeySource: ZulipTokenSource = configApiKey ? "config" : envApiKey ? "env" : "none";
-  const emailSource: ZulipEmailSource = configEmail ? "config" : envEmail ? "env" : "none";
-  const baseUrlSource: ZulipBaseUrlSource = configUrlTrimmed
-    ? "config"
-    : envUrl || envSite || envRealm
-      ? "env"
-      : "none";
+  let apiKey: string | undefined;
+  let email: string | undefined;
+  let baseUrl: string | undefined;
+  let apiKeySource: ZulipTokenSource = "none";
+  let emailSource: ZulipEmailSource = "none";
+  let baseUrlSource: ZulipBaseUrlSource = "none";
+
+  const envUrlAny = envUrl || envSite || envRealm;
+
+  if (allowEnv) {
+    // Default account: Env-first, then config.
+    apiKey = envApiKey || configApiKey;
+    email = envEmail || configEmail;
+    baseUrl = normalizeZulipBaseUrl(envUrlAny || configUrlTrimmed);
+
+    apiKeySource = envApiKey ? "env" : configApiKey ? "config" : "none";
+    emailSource = envEmail ? "env" : configEmail ? "config" : "none";
+    baseUrlSource = envUrlAny ? "env" : configUrlTrimmed ? "config" : "none";
+  } else {
+    // Non-default accounts: Config-only. No magic env discovery.
+    apiKey = configApiKey;
+    email = configEmail;
+    baseUrl = normalizeZulipBaseUrl(configUrlTrimmed);
+
+    apiKeySource = configApiKey ? "config" : "none";
+    emailSource = configEmail ? "config" : "none";
+    baseUrlSource = configUrlTrimmed ? "config" : "none";
+  }
+
+  const requireMention = resolveZulipRequireMention(merged);
 
   return {
     accountId,

--- a/test-loader.js
+++ b/test-loader.js
@@ -1,0 +1,18 @@
+import { register } from 'node:module';
+import { pathToFileURL } from 'node:url';
+import { resolve as pathResolve } from 'node:path';
+import { existsSync } from 'node:fs';
+
+export function resolve(specifier, context, nextResolve) {
+  if (specifier.startsWith('./') || specifier.startsWith('../')) {
+    if (specifier.endsWith('.js')) {
+      const tsSpecifier = specifier.slice(0, -3) + '.ts';
+      const parentURL = new URL(context.parentURL);
+      const tsURL = new URL(tsSpecifier, parentURL);
+      if (existsSync(pathResolve(parentURL.pathname, '..', tsSpecifier))) {
+         return nextResolve(tsSpecifier, context);
+      }
+    }
+  }
+  return nextResolve(specifier, context);
+}

--- a/test/accounts.test.ts
+++ b/test/accounts.test.ts
@@ -1,0 +1,88 @@
+import assert from "node:assert";
+import { test, describe, beforeEach, afterEach } from "node:test";
+import { resolveZulipAccount } from "../src/zulip/accounts.ts";
+import { DEFAULT_ACCOUNT_ID } from "openclaw/plugin-sdk/core";
+
+describe("resolveZulipAccount Precedence", () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  test("resolves from environment variables for default account", () => {
+    process.env.ZULIP_API_KEY = "env-api-key";
+    process.env.ZULIP_EMAIL = "env-email@example.com";
+    process.env.ZULIP_URL = "https://env.zulipchat.com";
+
+    const resolved = resolveZulipAccount({
+      cfg: { channels: { zulip: { enabled: true } } } as any,
+      accountId: DEFAULT_ACCOUNT_ID,
+    });
+
+    assert.strictEqual(resolved.apiKey, "env-api-key");
+    assert.strictEqual(resolved.email, "env-email@example.com");
+    assert.strictEqual(resolved.baseUrl, "https://env.zulipchat.com");
+    assert.strictEqual(resolved.apiKeySource, "env");
+    assert.strictEqual(resolved.emailSource, "env");
+    assert.strictEqual(resolved.baseUrlSource, "env");
+  });
+
+  test("environment variables take precedence over config for default account", () => {
+    process.env.ZULIP_API_KEY = "env-api-key";
+    process.env.ZULIP_EMAIL = "env-email@example.com";
+    process.env.ZULIP_URL = "https://env.zulipchat.com";
+
+    const resolved = resolveZulipAccount({
+      cfg: {
+        channels: {
+          zulip: {
+            enabled: true,
+            apiKey: "config-api-key",
+            email: "config@example.com",
+            url: "https://config.zulipchat.com"
+          }
+        }
+      } as any,
+      accountId: DEFAULT_ACCOUNT_ID,
+    });
+
+    // Should be env, not config
+    assert.strictEqual(resolved.apiKey, "env-api-key");
+    assert.strictEqual(resolved.email, "env-email@example.com");
+    assert.strictEqual(resolved.baseUrl, "https://env.zulipchat.com");
+    assert.strictEqual(resolved.apiKeySource, "env");
+    assert.strictEqual(resolved.emailSource, "env");
+    assert.strictEqual(resolved.baseUrlSource, "env");
+  });
+
+  test("does not use environment variables for non-default accounts", () => {
+    process.env.ZULIP_API_KEY = "env-api-key";
+
+    const resolved = resolveZulipAccount({
+      cfg: {
+        channels: {
+          zulip: {
+            enabled: true,
+            accounts: {
+              "other": {
+                enabled: true,
+                apiKey: "other-config-api-key",
+                email: "other@example.com",
+                url: "https://other.zulipchat.com"
+              }
+            }
+          }
+        }
+      } as any,
+      accountId: "other",
+    });
+
+    assert.strictEqual(resolved.apiKey, "other-config-api-key");
+    assert.strictEqual(resolved.apiKeySource, "config");
+  });
+});


### PR DESCRIPTION
This change moves Zulip secrets (API key, email, and base URL) to environment-based configuration for the default account. It ensures that environment variables take precedence over configuration file fields, which is the recommended approach for staging and production environments to avoid plaintext credential storage. For non-default accounts, the logic has been tightened to require explicit configuration in the config file, preventing accidental secret leakage through "magic" environment discovery. The change includes a new test suite, updated documentation, and a refined test infrastructure to support ESM-based TypeScript testing.

Fixes #4

---
*PR created automatically by Jules for task [9107375076181059416](https://jules.google.com/task/9107375076181059416) started by @niyazmft*