### PR TITLE
Implement durable dedupe store

### DIFF
--- a/src/zulip/dedupe-store.ts
+++ b/src/zulip/dedupe-store.ts
@@ -1,0 +1,112 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import type { PluginRuntime } from "openclaw/plugin-sdk";
+
+export type DedupeStoreOpts = {
+  accountId: string;
+  runtime: PluginRuntime;
+  ttlMs: number;
+  maxSize: number;
+};
+
+export class ZulipDedupeStore {
+  private accountId: string;
+  private runtime: PluginRuntime;
+  private ttlMs: number;
+  private maxSize: number;
+  private cache = new Map<string, number>();
+
+  constructor(opts: DedupeStoreOpts) {
+    this.accountId = opts.accountId;
+    this.runtime = opts.runtime;
+    this.ttlMs = opts.ttlMs;
+    this.maxSize = opts.maxSize;
+  }
+
+  private getPersistencePath(): string {
+    const safeAccountId = this.accountId.replace(/[^a-z0-9]/gi, "_");
+    return path.join(os.tmpdir(), `zulip_dedupe_${safeAccountId}.json`);
+  }
+
+  /**
+   * Loads the persisted dedupe state from disk.
+   */
+  async load(): Promise<void> {
+    try {
+      const p = this.getPersistencePath();
+      const data = await fs.readFile(p, "utf8");
+      const entries = JSON.parse(data) as [string, number][];
+      this.cache = new Map(entries);
+      this.prune(Date.now());
+    } catch (err) {
+      // Ignore errors (file not found, etc.)
+    }
+  }
+
+  /**
+   * Saves the current dedupe state to disk.
+   */
+  async save(): Promise<void> {
+    try {
+      const p = this.getPersistencePath();
+      const entries = Array.from(this.cache.entries());
+      await fs.writeFile(p, JSON.stringify(entries), "utf8");
+    } catch (err) {
+      this.runtime.error?.(
+        `zulip dedupe store [${this.accountId}]: failed to save: ${String(err)}`,
+      );
+    }
+  }
+
+  /**
+   * Checks if a key has been seen recently.
+   * Returns true if it was already in the cache (and not expired), false otherwise.
+   * If it's a new key, it's added to the cache and persisted.
+   */
+  async check(key: string, now = Date.now()): Promise<boolean> {
+    if (!key) {
+      return false;
+    }
+
+    const existing = this.cache.get(key);
+    if (existing !== undefined && (this.ttlMs <= 0 || now - existing < this.ttlMs)) {
+      this.touch(key, now);
+      return true;
+    }
+
+    this.touch(key, now);
+    this.prune(now);
+    await this.save();
+    return false;
+  }
+
+  private touch(key: string, now: number) {
+    this.cache.delete(key);
+    this.cache.set(key, now);
+  }
+
+  private prune(now: number) {
+    const cutoff = this.ttlMs > 0 ? now - this.ttlMs : undefined;
+    if (cutoff !== undefined) {
+      for (const [entryKey, entryTs] of this.cache.entries()) {
+        if (entryTs < cutoff) {
+          this.cache.delete(entryKey);
+        } else {
+          // Entries are ordered by insertion/touch, so we can break early.
+          break;
+        }
+      }
+    }
+
+    if (this.maxSize > 0) {
+      while (this.cache.size > this.maxSize) {
+        const oldestKey = this.cache.keys().next().value as string | undefined;
+        if (oldestKey === undefined) {
+          break;
+        }
+        this.cache.delete(oldestKey);
+      }
+    }
+  }
+}

--- a/src/zulip/monitor.ts
+++ b/src/zulip/monitor.ts
@@ -37,11 +37,8 @@ import {
   type ZulipMessage,
   type ZulipStream,
 } from "./client.js";
-import {
-  createDedupeCache,
-  formatInboundFromLabel,
-  resolveThreadSessionKeys,
-} from "./monitor-helpers.js";
+import { formatInboundFromLabel, resolveThreadSessionKeys } from "./monitor-helpers.js";
+import { ZulipDedupeStore } from "./dedupe-store.js";
 import { sendMessageZulip } from "./send.js";
 import { ZulipQueueManager } from "./queue-manager.js";
 import { downloadZulipUpload, extractZulipUploadUrls, normalizeZulipEmojiName } from "./uploads.js";
@@ -61,11 +58,6 @@ const RECENT_MESSAGE_TTL_MS = 5 * 60_000;
 const RECENT_MESSAGE_MAX = 2000;
 const DEFAULT_ONCHAR_PREFIXES = [">", "!"];
 const DEFAULT_TOPIC = "general";
-
-const recentInboundMessages = createDedupeCache({
-  ttlMs: RECENT_MESSAGE_TTL_MS,
-  maxSize: RECENT_MESSAGE_MAX,
-});
 
 function resolveRuntime(opts: MonitorZulipOpts): RuntimeEnv {
   return (
@@ -269,13 +261,21 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
   const reactionSuccess = normalizeZulipEmojiName(reactionConfig.onSuccess ?? "check_mark");
   const reactionError = normalizeZulipEmojiName(reactionConfig.onError ?? "warning");
 
+  const dedupeStore = new ZulipDedupeStore({
+    accountId: account.accountId,
+    runtime,
+    ttlMs: RECENT_MESSAGE_TTL_MS,
+    maxSize: RECENT_MESSAGE_MAX,
+  });
+  await dedupeStore.load();
+
   const handleMessage = async (message: ZulipMessage) => {
     const messageId = String(message.id ?? "");
     if (!messageId) {
       return;
     }
     const dedupeKey = `${account.accountId}:${messageId}`;
-    if (recentInboundMessages.check(dedupeKey)) {
+    if (await dedupeStore.check(dedupeKey)) {
       return;
     }
 

--- a/test/dedupe-store.test.ts
+++ b/test/dedupe-store.test.ts
@@ -1,0 +1,127 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { ZulipDedupeStore } from "../src/zulip/dedupe-store.js";
+import type { PluginRuntime } from "openclaw/plugin-sdk";
+
+const mockRuntime: PluginRuntime = {
+  log: () => {},
+  error: () => {},
+  exit: (code: number) => {
+    throw new Error(`exit ${code}`);
+  },
+};
+
+test("ZulipDedupeStore: basic duplicate suppression", async () => {
+  const accountId = `test_basic_${Math.random()}`;
+  const store = new ZulipDedupeStore({
+    accountId,
+    runtime: mockRuntime,
+    ttlMs: 1000,
+    maxSize: 10,
+  });
+
+  const key = "msg1";
+  const now = Date.now();
+  assert.equal(await store.check(key, now), false, "First check should be false");
+  assert.equal(await store.check(key, now + 1), true, "Second check should be true");
+});
+
+test("ZulipDedupeStore: TTL expiry", async () => {
+  const accountId = `test_ttl_${Math.random()}`;
+  const ttlMs = 100;
+  const store = new ZulipDedupeStore({
+    accountId,
+    runtime: mockRuntime,
+    ttlMs,
+    maxSize: 10,
+  });
+
+  const key = "msg1";
+  const now = Date.now();
+  assert.equal(await store.check(key, now), false);
+  assert.equal(await store.check(key, now + 10), true);
+  // Ensure we are well past the TTL relative to the last touch (now + 10)
+  assert.equal(await store.check(key, now + ttlMs + 20), false, "Should expire after TTL");
+});
+
+test("ZulipDedupeStore: max size pruning", async () => {
+  const accountId = `test_size_${Math.random()}`;
+  const store = new ZulipDedupeStore({
+    accountId,
+    runtime: mockRuntime,
+    ttlMs: 1000000,
+    maxSize: 2,
+  });
+
+  const now = 1000000;
+  assert.equal(await store.check("msg1", now), false, "msg1 new");
+  assert.equal(await store.check("msg2", now + 1), false, "msg2 new");
+
+  // Re-checking msg1 should move it to the end (most recent).
+  assert.equal(await store.check("msg1", now + 2), true, "msg1 touched");
+
+  // Adding msg3 should prune the oldest entry, which is msg2.
+  assert.equal(await store.check("msg3", now + 3), false, "msg3 new");
+
+  // Cache is [msg1, msg3]
+  assert.equal(await store.check("msg1", now + 4), true, "msg1 should be present");
+  assert.equal(await store.check("msg3", now + 5), true, "msg3 should be present");
+  assert.equal(await store.check("msg2", now + 6), false, "msg2 should have been pruned");
+});
+
+test("ZulipDedupeStore: persistence across restarts", async () => {
+  const accountId = `test_persist_${Math.random()}`;
+  const store1 = new ZulipDedupeStore({
+    accountId,
+    runtime: mockRuntime,
+    ttlMs: 1000,
+    maxSize: 10,
+  });
+
+  const now = Date.now();
+  await store1.check("msg1", now);
+  await store1.save();
+
+  const store2 = new ZulipDedupeStore({
+    accountId,
+    runtime: mockRuntime,
+    ttlMs: 1000,
+    maxSize: 10,
+  });
+  await store2.load();
+
+  assert.equal(await store2.check("msg1", now + 1), true, "Should remember msg1 across restart");
+  assert.equal(await store2.check("msg2", now + 2), false, "Should not know msg2");
+});
+
+test("ZulipDedupeStore: load prunes expired entries", async () => {
+  const accountId = `test_load_prune_${Math.random()}`;
+  const ttlMs = 100;
+  const store1 = new ZulipDedupeStore({
+    accountId,
+    runtime: mockRuntime,
+    ttlMs,
+    maxSize: 10,
+  });
+
+  const now = Date.now();
+  await store1.check("msg1", now);
+  await store1.save();
+
+  // Simulate time passing beyond TTL
+  const store2 = new ZulipDedupeStore({
+    accountId,
+    runtime: mockRuntime,
+    ttlMs,
+    maxSize: 10,
+  });
+
+  // Wait a bit to ensure Date.now() inside store2.load() is after TTL
+  await new Promise(resolve => setTimeout(resolve, ttlMs + 10));
+  await store2.load();
+
+  assert.equal(await store2.check("msg1", Date.now()), false, "msg1 should have been pruned during load");
+});


### PR DESCRIPTION
This change introduces a persistent deduplication store for the Zulip channel plugin. Message IDs are now stored in a JSON file within `os.tmpdir()`, allowing deduplication state to survive process restarts. The store is bounded by both time (TTL) and size to prevent uncontrolled growth. It uses the account ID to separate state between different Zulip accounts. Integration tests verify that the store correctly handles duplicate suppression, TTL expiry, and persistence.

Fixes #5

---
*PR created automatically by Jules for task [10730596725468036629](https://jules.google.com/task/10730596725468036629) started by @niyazmft*