### PR TITLE
Define Zulip stream/group routing policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ The following environment variables are supported for the **default account**:
 
 Environment variables take precedence over configuration file fields for the default account. Non-default accounts must be configured via the configuration file.
 
-See [docs/config.md](docs/config.md) for more details.
+See [docs/config.md](docs/config.md) for more details on configuration and the supported **DM/Group policies**.
 
 ## Notes
 - This bootstrap is intended for staging validation before any production cutover.

--- a/docs/config.md
+++ b/docs/config.md
@@ -22,6 +22,35 @@ For the **default account**, environment variables **always take precedence** ov
 
 If you need to configure multiple Zulip accounts or other settings (like streams, DM policy, etc.), you can use the `channels.zulip` section in your OpenClaw configuration file.
 
+### Policy Configuration
+
+The bridge supports both Direct Message (DM) and Stream (Group) traffic. The behavior is controlled by several settings:
+
+#### Direct Message (DM) Policy (`dmPolicy`)
+| Policy | Behavior |
+| --- | --- |
+| `pairing` (default) | If the sender is not in `allowFrom`, a pairing code is sent. Once approved, the user is added to `allowFrom`. |
+| `allowlist` | Only users explicitly listed in `allowFrom` (or the persistent store) can trigger the agent. |
+| `open` | Anyone can send a DM to the bot. |
+| `disabled` | All DMs are ignored. |
+
+#### Stream/Group Policy (`groupPolicy`)
+| Policy | Behavior |
+| --- | --- |
+| `allowlist` (default) | Only messages from senders in `groupAllowFrom` (or `allowFrom` if `groupAllowFrom` is empty) are processed. |
+| `open` | Anyone in a monitored stream can trigger the agent, provided the mention/trigger requirements are met. |
+| `disabled` | All stream messages are ignored. |
+
+#### Mention & Trigger Settings
+- `requireMention` (boolean, default: `true`): If `true`, the bot must be @mentioned in streams to respond.
+- `chatmode`:
+  - `oncall` (default): Responds only when @mentioned. Sets `requireMention` to `true`.
+  - `onmessage`: Responds to every message in a stream. Sets `requireMention` to `false`.
+  - `onchar`: Responds only when a message starts with a trigger character (e.g., `>` or `!`). Sets `requireMention` to `true`, but the trigger character bypasses the @mention requirement.
+
+> **Note:** Control commands from authorized users always bypass the `requireMention` gate in streams.
+
+
 ### Default Account
 ```json
 {

--- a/src/group-mentions.ts
+++ b/src/group-mentions.ts
@@ -6,8 +6,5 @@ export function resolveZulipGroupRequireMention(params: ChannelGroupContext): bo
     cfg: params.cfg,
     accountId: params.accountId,
   });
-  if (typeof account.requireMention === "boolean") {
-    return account.requireMention;
-  }
-  return true;
+  return account.requireMention;
 }

--- a/src/zulip/monitor.ts
+++ b/src/zulip/monitor.ts
@@ -40,6 +40,7 @@ import {
 import { formatInboundFromLabel, resolveThreadSessionKeys } from "./monitor-helpers.js";
 import { ZulipDedupeStore } from "./dedupe-store.js";
 import { sendMessageZulip } from "./send.js";
+import { decidePolicy } from "./policy.js";
 import { ZulipQueueManager } from "./queue-manager.js";
 import { downloadZulipUpload, extractZulipUploadUrls, normalizeZulipEmojiName } from "./uploads.js";
 
@@ -397,67 +398,6 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
         ? dmPolicy === "open" || senderAllowedForCommands
         : commandGate.commandAuthorized;
 
-    if (kind === "dm") {
-      if (dmPolicy === "disabled") {
-        logVerboseMessage(`zulip: drop dm (dmPolicy=disabled sender=${senderId})`);
-        return;
-      }
-      if (dmPolicy !== "open" && !senderAllowedForCommands) {
-        if (dmPolicy === "pairing") {
-          const { code, created } = await core.channel.pairing.upsertPairingRequest({
-            channel: "zulip",
-            id: senderId,
-            meta: { name: senderName },
-          });
-          logVerboseMessage(`zulip: pairing request sender=${senderId} created=${created}`);
-          if (created) {
-            try {
-              await sendMessageZulip(
-                `user:${senderId}`,
-                core.channel.pairing.buildPairingReply({
-                  channel: "zulip",
-                  idLine: `Your Zulip email: ${senderId}`,
-                  code,
-                }),
-                { accountId: account.accountId },
-              );
-              opts.statusSink?.({ lastOutboundAt: Date.now() });
-            } catch (err) {
-              logVerboseMessage(`zulip: pairing reply failed for ${senderId}: ${String(err)}`);
-            }
-          }
-        } else {
-          logVerboseMessage(`zulip: drop dm sender=${senderId} (dmPolicy=${dmPolicy})`);
-        }
-        return;
-      }
-    } else {
-      if (groupPolicy === "disabled") {
-        logVerboseMessage("zulip: drop group message (groupPolicy=disabled)");
-        return;
-      }
-      if (groupPolicy === "allowlist") {
-        if (effectiveGroupAllowFrom.length === 0) {
-          logVerboseMessage("zulip: drop group message (no group allowlist)");
-          return;
-        }
-        if (!groupAllowedForCommands) {
-          logVerboseMessage(`zulip: drop group sender=${senderId} (not in groupAllowFrom)`);
-          return;
-        }
-      }
-    }
-
-    if (kind !== "dm" && commandGate.shouldBlock) {
-      logInboundDrop({
-        log: logVerboseMessage,
-        channel: "zulip",
-        reason: "control command (unauthorized)",
-        target: senderId,
-      });
-      return;
-    }
-
     const shouldRequireMention =
       kind !== "dm" &&
       core.channel.groups.resolveRequireMention({
@@ -467,20 +407,66 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
         groupId: channelId,
         requireMentionOverride: account.config.requireMention,
       });
-    const shouldBypassMention =
-      isControlCommand && shouldRequireMention && !wasMentioned && commandAuthorized;
-    const effectiveWasMentioned = wasMentioned || shouldBypassMention || oncharTriggered;
     const canDetectMention = Boolean(botUsername) || mentionRegexes.length > 0;
+
+    const policyResult = decidePolicy({
+      kind,
+      senderId,
+      senderName,
+      dmPolicy,
+      groupPolicy,
+      senderAllowedForCommands,
+      groupAllowedForCommands,
+      effectiveGroupAllowFromLength: effectiveGroupAllowFrom.length,
+      shouldRequireMention,
+      wasMentioned,
+      isControlCommand,
+      commandAuthorized,
+      oncharTriggered,
+      canDetectMention,
+    });
+
+    if (policyResult.shouldDrop) {
+      if (policyResult.shouldPair) {
+        const { code, created } = await core.channel.pairing.upsertPairingRequest({
+          channel: "zulip",
+          id: senderId,
+          meta: { name: senderName },
+        });
+        logVerboseMessage(`zulip: pairing request sender=${senderId} created=${created}`);
+        if (created) {
+          try {
+            await sendMessageZulip(
+              `user:${senderId}`,
+              core.channel.pairing.buildPairingReply({
+                channel: "zulip",
+                idLine: `Your Zulip email: ${senderId}`,
+                code,
+              }),
+              { accountId: account.accountId },
+            );
+            opts.statusSink?.({ lastOutboundAt: Date.now() });
+          } catch (err) {
+            logVerboseMessage(`zulip: pairing reply failed for ${senderId}: ${String(err)}`);
+          }
+        }
+      } else {
+        logInboundDrop({
+          log: logVerboseMessage,
+          channel: "zulip",
+          reason: policyResult.reason ?? "policy drop",
+          target: senderId,
+        });
+      }
+      return;
+    }
 
     if (oncharEnabled && !oncharTriggered && !wasMentioned && !isControlCommand) {
       return;
     }
 
-    if (kind !== "dm" && shouldRequireMention && canDetectMention) {
-      if (!effectiveWasMentioned) {
-        return;
-      }
-    }
+    const effectiveWasMentioned =
+      wasMentioned || (isControlCommand && commandAuthorized) || oncharTriggered;
 
     const bodySource = oncharTriggered ? oncharResult.stripped : rawText;
     const bodyText = normalizeMention(bodySource, botUsername);

--- a/src/zulip/policy.ts
+++ b/src/zulip/policy.ts
@@ -1,0 +1,73 @@
+/**
+ * Interface representing the context needed to make a policy decision.
+ */
+export interface PolicyContext {
+  kind: "dm" | "channel";
+  senderId: string;
+  senderName: string;
+  dmPolicy: string;
+  groupPolicy: string;
+  senderAllowedForCommands: boolean;
+  groupAllowedForCommands: boolean;
+  effectiveGroupAllowFromLength: number;
+  shouldRequireMention: boolean;
+  wasMentioned: boolean;
+  isControlCommand: boolean;
+  commandAuthorized: boolean;
+  oncharTriggered: boolean;
+  canDetectMention: boolean;
+}
+
+/**
+ * Result of the policy decision.
+ */
+export interface PolicyResult {
+  shouldDrop: boolean;
+  reason?: string;
+  shouldPair?: boolean;
+}
+
+/**
+ * Decides whether a message should be processed based on the current policy configuration.
+ */
+export function decidePolicy(ctx: PolicyContext): PolicyResult {
+  if (ctx.kind === "dm") {
+    if (ctx.dmPolicy === "disabled") {
+      return { shouldDrop: true, reason: "dmPolicy=disabled" };
+    }
+    if (ctx.dmPolicy !== "open" && !ctx.senderAllowedForCommands) {
+      if (ctx.dmPolicy === "pairing") {
+        return { shouldDrop: true, shouldPair: true, reason: "pairing" };
+      }
+      return { shouldDrop: true, reason: `dmPolicy=${ctx.dmPolicy}` };
+    }
+  } else {
+    if (ctx.groupPolicy === "disabled") {
+      return { shouldDrop: true, reason: "groupPolicy=disabled" };
+    }
+    if (ctx.groupPolicy === "allowlist") {
+      if (ctx.effectiveGroupAllowFromLength === 0) {
+        return { shouldDrop: true, reason: "no group allowlist" };
+      }
+      if (!ctx.groupAllowedForCommands) {
+        return { shouldDrop: true, reason: "not in groupAllowFrom" };
+      }
+    }
+
+    // Inbound drop for unauthorized control commands in channels
+    if (ctx.isControlCommand && !ctx.commandAuthorized) {
+      return { shouldDrop: true, reason: "control command (unauthorized)" };
+    }
+
+    // Mention gating for channels
+    if (ctx.shouldRequireMention && ctx.canDetectMention) {
+      const effectiveWasMentioned =
+        ctx.wasMentioned || (ctx.isControlCommand && ctx.commandAuthorized) || ctx.oncharTriggered;
+      if (!effectiveWasMentioned) {
+        return { shouldDrop: true, reason: "mention required" };
+      }
+    }
+  }
+
+  return { shouldDrop: false };
+}

--- a/test/policy.test.ts
+++ b/test/policy.test.ts
@@ -1,0 +1,293 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { decidePolicy } from "../src/zulip/policy.ts";
+
+test("Policy Logic: DM - open allows everyone", () => {
+  const result = decidePolicy({
+    kind: 'dm',
+    senderId: 'user1',
+    senderName: 'User One',
+    dmPolicy: 'open',
+    groupPolicy: 'allowlist',
+    senderAllowedForCommands: false,
+    groupAllowedForCommands: false,
+    effectiveGroupAllowFromLength: 0,
+    shouldRequireMention: false,
+    wasMentioned: false,
+    isControlCommand: false,
+    commandAuthorized: false,
+    oncharTriggered: false,
+    canDetectMention: true
+  });
+  assert.strictEqual(result.shouldDrop, false);
+});
+
+test("Policy Logic: DM - disabled drops everyone", () => {
+  const result = decidePolicy({
+    kind: 'dm',
+    senderId: 'user1',
+    senderName: 'User One',
+    dmPolicy: 'disabled',
+    groupPolicy: 'allowlist',
+    senderAllowedForCommands: true,
+    groupAllowedForCommands: true,
+    effectiveGroupAllowFromLength: 0,
+    shouldRequireMention: false,
+    wasMentioned: false,
+    isControlCommand: false,
+    commandAuthorized: false,
+    oncharTriggered: false,
+    canDetectMention: true
+  });
+  assert.strictEqual(result.shouldDrop, true);
+  assert.strictEqual(result.reason, "dmPolicy=disabled");
+});
+
+test("Policy Logic: DM - allowlist drops if not allowed", () => {
+  const result = decidePolicy({
+    kind: 'dm',
+    senderId: 'user1',
+    senderName: 'User One',
+    dmPolicy: 'allowlist',
+    groupPolicy: 'allowlist',
+    senderAllowedForCommands: false,
+    groupAllowedForCommands: false,
+    effectiveGroupAllowFromLength: 0,
+    shouldRequireMention: false,
+    wasMentioned: false,
+    isControlCommand: false,
+    commandAuthorized: false,
+    oncharTriggered: false,
+    canDetectMention: true
+  });
+  assert.strictEqual(result.shouldDrop, true);
+  assert.strictEqual(result.reason, "dmPolicy=allowlist");
+});
+
+test("Policy Logic: DM - allowlist allows if allowed", () => {
+  const result = decidePolicy({
+    kind: 'dm',
+    senderId: 'user1',
+    senderName: 'User One',
+    dmPolicy: 'allowlist',
+    groupPolicy: 'allowlist',
+    senderAllowedForCommands: true,
+    groupAllowedForCommands: false,
+    effectiveGroupAllowFromLength: 0,
+    shouldRequireMention: false,
+    wasMentioned: false,
+    isControlCommand: false,
+    commandAuthorized: true,
+    oncharTriggered: false,
+    canDetectMention: true
+  });
+  assert.strictEqual(result.shouldDrop, false);
+});
+
+test("Policy Logic: DM - pairing triggers pairing if not allowed", () => {
+  const result = decidePolicy({
+    kind: 'dm',
+    senderId: 'user1',
+    senderName: 'User One',
+    dmPolicy: 'pairing',
+    groupPolicy: 'allowlist',
+    senderAllowedForCommands: false,
+    groupAllowedForCommands: false,
+    effectiveGroupAllowFromLength: 0,
+    shouldRequireMention: false,
+    wasMentioned: false,
+    isControlCommand: false,
+    commandAuthorized: false,
+    oncharTriggered: false,
+    canDetectMention: true
+  });
+  assert.strictEqual(result.shouldDrop, true);
+  assert.strictEqual(result.shouldPair, true);
+  assert.strictEqual(result.reason, "pairing");
+});
+
+test("Policy Logic: Group - disabled drops everyone", () => {
+  const result = decidePolicy({
+    kind: 'channel',
+    senderId: 'user1',
+    senderName: 'User One',
+    dmPolicy: 'open',
+    groupPolicy: 'disabled',
+    senderAllowedForCommands: true,
+    groupAllowedForCommands: true,
+    effectiveGroupAllowFromLength: 1,
+    shouldRequireMention: true,
+    wasMentioned: true,
+    isControlCommand: false,
+    commandAuthorized: false,
+    oncharTriggered: false,
+    canDetectMention: true
+  });
+  assert.strictEqual(result.shouldDrop, true);
+  assert.strictEqual(result.reason, "groupPolicy=disabled");
+});
+
+test("Policy Logic: Group - open allows everyone if mentioned", () => {
+  const result = decidePolicy({
+    kind: 'channel',
+    senderId: 'user1',
+    senderName: 'User One',
+    dmPolicy: 'open',
+    groupPolicy: 'open',
+    senderAllowedForCommands: false,
+    groupAllowedForCommands: false,
+    effectiveGroupAllowFromLength: 0,
+    shouldRequireMention: true,
+    wasMentioned: true,
+    isControlCommand: false,
+    commandAuthorized: false,
+    oncharTriggered: false,
+    canDetectMention: true
+  });
+  assert.strictEqual(result.shouldDrop, false);
+});
+
+test("Policy Logic: Group - open drops if not mentioned", () => {
+  const result = decidePolicy({
+    kind: 'channel',
+    senderId: 'user1',
+    senderName: 'User One',
+    dmPolicy: 'open',
+    groupPolicy: 'open',
+    senderAllowedForCommands: false,
+    groupAllowedForCommands: false,
+    effectiveGroupAllowFromLength: 0,
+    shouldRequireMention: true,
+    wasMentioned: false,
+    isControlCommand: false,
+    commandAuthorized: false,
+    oncharTriggered: false,
+    canDetectMention: true
+  });
+  assert.strictEqual(result.shouldDrop, true);
+  assert.strictEqual(result.reason, "mention required");
+});
+
+test("Policy Logic: Group - allowlist drops if not in allowlist", () => {
+  const result = decidePolicy({
+    kind: 'channel',
+    senderId: 'user1',
+    senderName: 'User One',
+    dmPolicy: 'open',
+    groupPolicy: 'allowlist',
+    senderAllowedForCommands: false,
+    groupAllowedForCommands: false,
+    effectiveGroupAllowFromLength: 1, // list is not empty
+    shouldRequireMention: true,
+    wasMentioned: true,
+    isControlCommand: false,
+    commandAuthorized: false,
+    oncharTriggered: false,
+    canDetectMention: true
+  });
+  assert.strictEqual(result.shouldDrop, true);
+  assert.strictEqual(result.reason, "not in groupAllowFrom");
+});
+
+test("Policy Logic: Group - allowlist allows if in allowlist", () => {
+  const result = decidePolicy({
+    kind: 'channel',
+    senderId: 'user1',
+    senderName: 'User One',
+    dmPolicy: 'open',
+    groupPolicy: 'allowlist',
+    senderAllowedForCommands: false,
+    groupAllowedForCommands: true,
+    effectiveGroupAllowFromLength: 1,
+    shouldRequireMention: true,
+    wasMentioned: true,
+    isControlCommand: false,
+    commandAuthorized: false,
+    oncharTriggered: false,
+    canDetectMention: true
+  });
+  assert.strictEqual(result.shouldDrop, false);
+});
+
+test("Policy Logic: Group - allowlist drops if allowlist is empty", () => {
+  const result = decidePolicy({
+    kind: 'channel',
+    senderId: 'user1',
+    senderName: 'User One',
+    dmPolicy: 'open',
+    groupPolicy: 'allowlist',
+    senderAllowedForCommands: true,
+    groupAllowedForCommands: true,
+    effectiveGroupAllowFromLength: 0,
+    shouldRequireMention: true,
+    wasMentioned: true,
+    isControlCommand: false,
+    commandAuthorized: false,
+    oncharTriggered: false,
+    canDetectMention: true
+  });
+  assert.strictEqual(result.shouldDrop, true);
+  assert.strictEqual(result.reason, "no group allowlist");
+});
+
+test("Policy Logic: Group - bypassed mention for authorized control command", () => {
+  const result = decidePolicy({
+    kind: 'channel',
+    senderId: 'user1',
+    senderName: 'User One',
+    dmPolicy: 'open',
+    groupPolicy: 'open',
+    senderAllowedForCommands: true,
+    groupAllowedForCommands: true,
+    effectiveGroupAllowFromLength: 0,
+    shouldRequireMention: true,
+    wasMentioned: false,
+    isControlCommand: true,
+    commandAuthorized: true,
+    oncharTriggered: false,
+    canDetectMention: true
+  });
+  assert.strictEqual(result.shouldDrop, false);
+});
+
+test("Policy Logic: Group - onchar triggered bypasses mention", () => {
+  const result = decidePolicy({
+    kind: 'channel',
+    senderId: 'user1',
+    senderName: 'User One',
+    dmPolicy: 'open',
+    groupPolicy: 'open',
+    senderAllowedForCommands: false,
+    groupAllowedForCommands: false,
+    effectiveGroupAllowFromLength: 0,
+    shouldRequireMention: true,
+    wasMentioned: false,
+    isControlCommand: false,
+    commandAuthorized: false,
+    oncharTriggered: true,
+    canDetectMention: true
+  });
+  assert.strictEqual(result.shouldDrop, false);
+});
+
+test("Policy Logic: Group - cannot detect mention does not drop if mentioned but undetected", () => {
+  // If we can't detect mentions (no botUsername and no mentionRegexes), we shouldn't drop
+  // because we don't know if it was mentioned or not.
+  const result = decidePolicy({
+    kind: 'channel',
+    senderId: 'user1',
+    senderName: 'User One',
+    dmPolicy: 'open',
+    groupPolicy: 'open',
+    senderAllowedForCommands: false,
+    groupAllowedForCommands: false,
+    effectiveGroupAllowFromLength: 0,
+    shouldRequireMention: true,
+    wasMentioned: false,
+    isControlCommand: false,
+    commandAuthorized: false,
+    oncharTriggered: false,
+    canDetectMention: false
+  });
+  assert.strictEqual(result.shouldDrop, false);
+});


### PR DESCRIPTION
Refactored Zulip message routing policy enforcement. Centralized policy logic in `src/zulip/policy.ts`, added comprehensive tests in `test/policy.test.ts`, and updated documentation in `docs/config.md`. This change clarifies and tightens the bridge's behavior for DMs and Streams/Groups, including mention/trigger gating and authorized command bypasses.

Fixes #6

---
*PR created automatically by Jules for task [3540678042321645702](https://jules.google.com/task/3540678042321645702) started by @niyazmft*