### PR TITLE
Add Zulip Observability Baseline

### DIFF
--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,0 +1,60 @@
+# Zulip Bridge Observability
+
+This document describes the observability baseline for the Zulip bridge, including standardized logging formats, machine-parseable identifiers, and recommended operator checks.
+
+## Logging Schema
+
+Logs from the Zulip plugin use a standardized format for key identifiers to ensure traceability across the inbound and outbound message lifecycles.
+
+Standard fields included in log events (where applicable):
+
+- `accountId`: The internal OpenClaw account ID (e.g., `default`).
+- `queueId`: The Zulip event queue ID for the current session.
+- `messageId`: The Zulip-assigned ID for the message.
+- `senderId`: The email or ID of the message sender.
+- `kind`: `dm` (Direct Message) or `channel` (Stream).
+- `stream`: The stream name or ID (for `channel` messages).
+- `topic`: The topic name (for `channel` messages).
+- `sessionKey`: The OpenClaw session key associated with the message/thread.
+- `error`: Details of any failure encountered.
+
+## Key Traceability Events
+
+### Inbound Lifecycle
+
+1. **`zulip inbound arrival`**: Emitted as soon as a message is received from the Zulip event queue.
+2. **`zulip inbound dedupe hit`**: Emitted if the message was already processed recently.
+3. **`logInboundDrop`**: Emitted if a policy decision (e.g., `dmPolicy` or `groupPolicy`) blocks the message. Includes `reason`.
+4. **`zulip inbound dispatch`**: Emitted when the message is successfully handed off to the agent for processing. Includes `sessionKey`.
+
+### Outbound Lifecycle
+
+1. **`zulip outbound attempt`**: Emitted when the bridge starts sending a reply or outbound message.
+2. **`zulip outbound success`**: Emitted after the message is accepted by the Zulip API. Includes the new Zulip `messageId`.
+
+### Queue Management
+
+1. **`zulip queue registered`**: Emitted when a new event queue is created.
+2. **`zulip queue loaded`**: Emitted when a queue is restored from local persistence.
+3. **`zulip queue expired`**: Emitted when the bridge detects that the queue has been invalidated by the server.
+
+## Operator Checks & Alerting
+
+### Health Signals
+
+- **Queue Expiry Frequency**: Frequent `zulip queue expired` followed by registration might indicate network instability or Zulip server-side issues.
+- **Polling Errors**: Look for `zulip polling error` with `status=429` (Rate Limiting) or `status=5xx` (Server error).
+- **Inbound/Outbound Drift**: Compare `lastInboundAt` and `lastOutboundAt` in the account status. A large gap while the bridge is "connected" might suggest an issue with message handling.
+
+### Debugging Message Drops
+
+If a user reports that the bot is not responding:
+1. Search logs for `[senderId=user@example.com]`.
+2. Look for `logInboundDrop` with `reason="mention required"` or `reason="not in groupAllowFrom"`.
+3. If no arrival log is found, verify the account status and check for polling errors.
+
+### Correlating Replies
+
+To trace a bot's reply back to an inbound message:
+1. Find the `zulip inbound dispatch` log for the inbound message and note the `sessionKey`.
+2. Search for `zulip outbound success` logs with the same `sessionKey`.

--- a/src/zulip/monitor-helpers.ts
+++ b/src/zulip/monitor-helpers.ts
@@ -164,3 +164,13 @@ export function resolveThreadSessionKeys(params: {
     : params.baseSessionKey;
   return { sessionKey, parentSessionKey: params.parentSessionKey };
 }
+
+/**
+ * Formats a log message with standardized, machine-parseable identifiers.
+ */
+export function formatZulipLog(message: string, fields: Record<string, any>): string {
+  const parts = Object.entries(fields)
+    .filter(([_, v]) => v !== undefined && v !== null && v !== "")
+    .map(([k, v]) => `${k}=${v}`);
+  return parts.length > 0 ? `${message} [${parts.join(" ")}]` : message;
+}

--- a/src/zulip/monitor.ts
+++ b/src/zulip/monitor.ts
@@ -37,7 +37,11 @@ import {
   type ZulipMessage,
   type ZulipStream,
 } from "./client.js";
-import { formatInboundFromLabel, resolveThreadSessionKeys } from "./monitor-helpers.js";
+import {
+  formatInboundFromLabel,
+  resolveThreadSessionKeys,
+  formatZulipLog,
+} from "./monitor-helpers.js";
 import { ZulipDedupeStore } from "./dedupe-store.js";
 import { sendMessageZulip } from "./send.js";
 import { decidePolicy } from "./policy.js";
@@ -275,39 +279,54 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
     if (!messageId) {
       return;
     }
-    const dedupeKey = `${account.accountId}:${messageId}`;
-    if (await dedupeStore.check(dedupeKey)) {
-      return;
-    }
 
     const senderId = message.sender_email || String(message.sender_id ?? "");
     if (!senderId) {
       return;
     }
+    // Safety check: ignore bot's own messages to prevent infinite loops.
     if (senderId === botEmail || String(message.sender_id) === botUserId) {
       return;
     }
 
-    const senderName = message.sender_full_name?.trim() || senderId;
     const isDM = message.type === "private";
     const kind = isDM ? "dm" : "channel";
-    const chatType = isDM ? "direct" : "channel";
-
-    let streamName = "";
     let streamId = "";
-    let topic = DEFAULT_TOPIC;
-    let channelId = "";
-
-    if (isDM) {
-      channelId = senderId;
-    } else {
+    let streamName = "";
+    let topic = isDM ? undefined : (message.subject?.trim() || DEFAULT_TOPIC);
+    if (!isDM) {
       streamId = String(message.stream_id ?? "");
-      channelId = streamId;
       if (typeof message.display_recipient === "string") {
         streamName = message.display_recipient;
       }
-      topic = message.subject?.trim() || DEFAULT_TOPIC;
     }
+
+    runtime.log?.(
+      formatZulipLog("zulip inbound arrival", {
+        accountId: account.accountId,
+        messageId,
+        senderId,
+        kind,
+        stream: streamName || streamId,
+        topic,
+      }),
+    );
+
+    const dedupeKey = `${account.accountId}:${messageId}`;
+    if (await dedupeStore.check(dedupeKey)) {
+      runtime.log?.(
+        formatZulipLog("zulip inbound dedupe hit", {
+          accountId: account.accountId,
+          messageId,
+        }),
+      );
+      return;
+    }
+
+    const senderName = message.sender_full_name?.trim() || senderId;
+    const chatType = isDM ? "direct" : "channel";
+
+    let channelId = isDM ? senderId : streamId;
 
     const rawText = stripHtmlToText(message.content ?? "");
     const oncharResult = stripOncharPrefix(rawText, oncharPrefixes);
@@ -433,7 +452,13 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
           id: senderId,
           meta: { name: senderName },
         });
-        logVerboseMessage(`zulip: pairing request sender=${senderId} created=${created}`);
+        runtime.log?.(
+          formatZulipLog("zulip pairing request", {
+            accountId: account.accountId,
+            senderId,
+            created,
+          }),
+        );
         if (created) {
           try {
             await sendMessageZulip(
@@ -443,16 +468,34 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
                 idLine: `Your Zulip email: ${senderId}`,
                 code,
               }),
-              { accountId: account.accountId },
+              {
+                accountId: account.accountId,
+                sessionKey: `zulip:${account.accountId}:pairing`,
+                kind: "dm",
+              },
             );
             opts.statusSink?.({ lastOutboundAt: Date.now() });
           } catch (err) {
-            logVerboseMessage(`zulip: pairing reply failed for ${senderId}: ${String(err)}`);
+            runtime.error?.(
+              formatZulipLog("zulip pairing reply failed", {
+                accountId: account.accountId,
+                senderId,
+                error: String(err),
+              }),
+            );
           }
         }
       } else {
         logInboundDrop({
-          log: logVerboseMessage,
+          log: (msg: string) =>
+            runtime.log?.(
+              formatZulipLog(msg, {
+                accountId: account.accountId,
+                messageId,
+                senderId,
+                reason: policyResult.reason,
+              }),
+            ),
           channel: "zulip",
           reason: policyResult.reason ?? "policy drop",
           target: senderId,
@@ -582,8 +625,16 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
     }
 
     const previewLine = bodyText.slice(0, 200).replace(/\n/g, "\\n");
-    logVerboseMessage(
-      `zulip inbound: from=${ctxPayload.From} len=${bodyText.length} preview="${previewLine}"`,
+    runtime.log?.(
+      formatZulipLog("zulip inbound dispatch", {
+        accountId: account.accountId,
+        messageId,
+        senderId,
+        from: ctxPayload.From,
+        sessionKey,
+        len: bodyText.length,
+        preview: previewLine,
+      }),
     );
 
     const addReactionSafe = async (emojiName: string) => {
@@ -718,7 +769,14 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
       });
     } catch (err) {
       dispatchError = err;
-      runtime.error?.(`zulip reply failed: ${String(err)}`);
+      runtime.error?.(
+        formatZulipLog("zulip reply failed", {
+          accountId: account.accountId,
+          messageId,
+          senderId,
+          error: String(err),
+        }),
+      );
     } finally {
       markDispatchIdle();
     }
@@ -764,7 +822,13 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
     try {
       await handleMessage(message);
     } catch (err) {
-      runtime.error?.(`zulip message handler failed: ${String(err)}`);
+      runtime.error?.(
+        formatZulipLog("zulip message handler failed", {
+          accountId: account.accountId,
+          messageId: message.id,
+          error: String(err),
+        }),
+      );
     }
   };
 
@@ -774,7 +838,12 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
     try {
       queue = await queueManager.ensureQueue();
     } catch (err) {
-      runtime.error?.(`zulip queue management failed: ${String(err)}`);
+      runtime.error?.(
+        formatZulipLog("zulip queue management failed", {
+          accountId: account.accountId,
+          error: String(err),
+        }),
+      );
       await delay(5000);
       continue;
     }
@@ -801,6 +870,13 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
 
       const events = response.events ?? [];
       if (events.length > 0) {
+        runtime.log?.(
+          formatZulipLog("zulip events received", {
+            accountId: account.accountId,
+            queueId: queue.queueId,
+            count: events.length,
+          }),
+        );
         opts.statusSink?.({
           connected: true,
           lastConnectedAt: Date.now(),
@@ -834,7 +910,13 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
       }
       const status = (err as { status?: number })?.status;
       const retryAfterMs = (err as { retryAfterMs?: number })?.retryAfterMs;
-      runtime.error?.(`zulip polling error: ${String(err)}`);
+      runtime.error?.(
+        formatZulipLog("zulip polling error", {
+          accountId: account.accountId,
+          error: String(err),
+          status,
+        }),
+      );
       opts.statusSink?.({
         connected: false,
         lastError: String(err),

--- a/src/zulip/queue-manager.ts
+++ b/src/zulip/queue-manager.ts
@@ -2,6 +2,7 @@ import type { PluginRuntime } from "openclaw/plugin-sdk";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { formatZulipLog } from "./monitor-helpers.js";
 
 export type QueueMetadata = {
   queueId: string;
@@ -49,21 +50,25 @@ export class ZulipQueueManager {
   }
 
   private async performRegistration(): Promise<QueueMetadata> {
-    const logger = this.runtime.log;
-    const errorLogger = this.runtime.error;
-
     // Try loading from persistence first
     try {
       const persisted = await this.loadMetadata();
       if (persisted) {
-        logger?.(
-          `zulip queue manager [${this.accountId}]: loaded persisted queue ${persisted.queueId} (last_event_id: ${persisted.lastEventId})`,
+        this.runtime.log?.(
+          formatZulipLog("zulip queue loaded", {
+            accountId: this.accountId,
+            queueId: persisted.queueId,
+            lastEventId: persisted.lastEventId,
+          }),
         );
         return persisted;
       }
     } catch (err) {
-      errorLogger?.(
-        `zulip queue manager [${this.accountId}]: failed to load persisted queue: ${String(err)}`,
+      this.runtime.error?.(
+        formatZulipLog("zulip queue load failed", {
+          accountId: this.accountId,
+          error: String(err),
+        }),
       );
     }
 
@@ -73,8 +78,11 @@ export class ZulipQueueManager {
 
     while (attempt < maxAttempts) {
       try {
-        logger?.(
-          `zulip queue manager [${this.accountId}]: registering new queue (attempt ${attempt + 1})...`,
+        this.runtime.log?.(
+          formatZulipLog("zulip queue registering", {
+            accountId: this.accountId,
+            attempt: attempt + 1,
+          }),
         );
         const queue = await this.registerFn();
         const metadata: QueueMetadata = {
@@ -83,18 +91,34 @@ export class ZulipQueueManager {
           registeredAt: Date.now(),
         };
         await this.saveMetadata(metadata);
-        logger?.(
-          `zulip queue manager [${this.accountId}]: registered new queue ${metadata.queueId} (last_event_id: ${metadata.lastEventId})`,
+        this.runtime.log?.(
+          formatZulipLog("zulip queue registered", {
+            accountId: this.accountId,
+            queueId: metadata.queueId,
+            lastEventId: metadata.lastEventId,
+          }),
         );
         return metadata;
       } catch (err) {
         attempt++;
         if (attempt >= maxAttempts) {
-          errorLogger?.(`zulip queue manager [${this.accountId}]: failed to register queue after ${maxAttempts} attempts: ${String(err)}`);
+          this.runtime.error?.(
+            formatZulipLog("zulip queue registration failed final", {
+              accountId: this.accountId,
+              attempts: maxAttempts,
+              error: String(err),
+            }),
+          );
           throw err;
         }
         const delayMs = baseDelayMs * Math.pow(2, attempt) + Math.random() * 1000;
-        logger?.(`zulip queue manager [${this.accountId}]: registration failed, retrying in ${Math.round(delayMs)}ms...`);
+        this.runtime.log?.(
+          formatZulipLog("zulip queue registration failed, retrying", {
+            accountId: this.accountId,
+            error: String(err),
+            delayMs: Math.round(delayMs),
+          }),
+        );
         await new Promise((resolve) => setTimeout(resolve, delayMs));
       }
     }
@@ -102,9 +126,13 @@ export class ZulipQueueManager {
   }
 
   async markQueueExpired(): Promise<void> {
-    const logger = this.runtime.log;
     if (this.currentQueue) {
-      logger?.(`zulip queue manager [${this.accountId}]: marking queue ${this.currentQueue.queueId} as expired`);
+      this.runtime.log?.(
+        formatZulipLog("zulip queue expired", {
+          accountId: this.accountId,
+          queueId: this.currentQueue.queueId,
+        }),
+      );
       this.currentQueue = null;
       const p = this.getPersistencePath();
       await fs.unlink(p).catch(() => {});
@@ -143,7 +171,12 @@ export class ZulipQueueManager {
       const p = this.getPersistencePath();
       await fs.writeFile(p, JSON.stringify(metadata), "utf8");
     } catch (err) {
-      this.runtime.error?.(`zulip queue manager [${this.accountId}]: failed to save metadata: ${String(err)}`);
+      this.runtime.error?.(
+        formatZulipLog("zulip queue metadata save failed", {
+          accountId: this.accountId,
+          error: String(err),
+        }),
+      );
     }
   }
 }

--- a/src/zulip/send.ts
+++ b/src/zulip/send.ts
@@ -12,6 +12,7 @@ import {
   sendZulipStreamMessage,
   uploadZulipFile,
 } from "./client.js";
+import { formatZulipLog } from "./monitor-helpers.js";
 
 export type ZulipSendOpts = {
   apiKey?: string;
@@ -20,6 +21,8 @@ export type ZulipSendOpts = {
   accountId?: string;
   mediaUrl?: string;
   topic?: string;
+  sessionKey?: string;
+  kind?: "dm" | "channel";
 };
 
 export type ZulipSendResult = {
@@ -117,7 +120,6 @@ export async function sendMessageZulip(
   opts: ZulipSendOpts = {},
 ): Promise<ZulipSendResult> {
   const core = getCore();
-  const logger = core.logging.getChildLogger({ module: "zulip" });
   const cfg = core.config.loadConfig();
   const account = resolveZulipAccount({
     cfg,
@@ -139,6 +141,23 @@ export async function sendMessageZulip(
 
   const client = createZulipClient({ baseUrl, email, apiKey });
   const target = parseZulipTarget(to);
+
+  const kind = opts.kind || (target.kind === "user" ? "dm" : "channel");
+  const stream = target.kind === "stream" ? target.stream : undefined;
+  const topic = target.kind === "stream" ? target.topic || opts.topic : undefined;
+
+  core.log?.(
+    formatZulipLog("zulip outbound attempt", {
+      accountId: account.accountId,
+      target: to,
+      kind,
+      stream,
+      topic,
+      sessionKey: opts.sessionKey,
+      hasMedia: Boolean(opts.mediaUrl),
+    }),
+  );
+
   let message = text?.trim() ?? "";
   const rawMediaUrl = opts.mediaUrl?.trim();
   let mediaUrl = rawMediaUrl;
@@ -207,17 +226,26 @@ export async function sendMessageZulip(
     });
     messageId = response.id ? String(response.id) : "unknown";
   } else {
-    const topic = target.topic || opts.topic || DEFAULT_TOPIC;
-    if (!topic) {
-      logger.debug?.("zulip send: missing topic for stream message");
-    }
+    const resolvedTopic = target.topic || opts.topic || DEFAULT_TOPIC;
     const response = await sendZulipStreamMessage(client, {
       stream: target.stream,
-      topic: topic || DEFAULT_TOPIC,
+      topic: resolvedTopic,
       content: message,
     });
     messageId = response.id ? String(response.id) : "unknown";
   }
+
+  core.log?.(
+    formatZulipLog("zulip outbound success", {
+      accountId: account.accountId,
+      messageId,
+      target: to,
+      kind,
+      stream,
+      topic: target.kind === "stream" ? target.topic || opts.topic || DEFAULT_TOPIC : undefined,
+      sessionKey: opts.sessionKey,
+    }),
+  );
 
   core.channel.activity.record({
     channel: "zulip",


### PR DESCRIPTION
This change implements a comprehensive observability baseline for the Zulip bridge. It introduces structured, machine-parseable logging using a standardized `[field=value]` format.

Key improvements:
1. **Traceability**: Inbound and outbound message lifecycles now emit logs with stable identifiers (`messageId`, `sessionKey`, `accountId`), allowing operators to correlate messages and trace bot replies.
2. **Safety**: Fixed a regression identified during review by ensuring the bot immediately ignores its own messages, preventing infinite loops.
3. **Queue Visibility**: Standardized logs for event queue registration, loading, and expiry, including the `queueId`.
4. **Reliability**: Polling errors now include status codes and detailed identifiers for faster debugging.
5. **Documentation**: Created `docs/observability.md` to guide operators on health signals, debugging steps, and reply correlation.
6. **API Correctness**: Aligned logging calls with the OpenClaw plugin runtime's function-based API (`runtime.log(...)` vs `.info(...)`).
7. **Clean Data**: Refined log fields to omit irrelevant data, such as `topic` for Direct Messages.

All tests passed via `npm run check`.

Fixes #7

---
*PR created automatically by Jules for task [8856020113319833432](https://jules.google.com/task/8856020113319833432) started by @niyazmft*