### PR TITLE
Add CI and smoke test harness (#8)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,3 +15,5 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npm run check
+      - name: Enforce pristine working directory
+        run: git diff --exit-code || { echo "Working directory is not clean. Lockfile or generated files might be out of sync."; false; }

--- a/docs/smoke-test.md
+++ b/docs/smoke-test.md
@@ -1,0 +1,58 @@
+# Zulip Bridge Smoke Test
+
+This document provides a manual smoke testing checklist for the OpenClaw Zulip Bridge to ensure staging validation is successful before deploying to production.
+
+## Prerequisites
+
+1.  A staging OpenClaw runtime environment.
+2.  A test Zulip organization (realm) where you have administrative access or can create bots.
+3.  A dedicated Zulip bot account for staging (`ZULIP_EMAIL`, `ZULIP_API_KEY`, `ZULIP_URL`).
+4.  At least two test user accounts in the Zulip organization.
+5.  A dedicated test stream (e.g., `#staging-test`).
+
+## Checklist
+
+### 1. Configuration & Startup
+- [ ] Configure the bridge in the staging OpenClaw environment using environment variables (`ZULIP_EMAIL`, `ZULIP_API_KEY`, `ZULIP_URL`).
+- [ ] Start the OpenClaw runtime.
+- [ ] Verify the bridge initializes without errors in the logs.
+- [ ] Check logs for `[zulip] [action=queue_registered]` indicating a successful connection to the Zulip events API.
+
+### 2. Direct Messages (DM) Policy
+- [ ] Send a DM from a test user to the bot.
+- [ ] Verify the message appears in the OpenClaw runtime.
+- [ ] Verify the bot responds correctly back to the user via DM.
+- [ ] Check logs for `[action=message_arrival]` and `[action=dispatched_to_openclaw]`.
+
+### 3. Stream/Group Policy (Mention Handling)
+- [ ] Add the bot to the test stream.
+- [ ] Post a message in the stream *without* mentioning the bot.
+- [ ] Verify the message is ignored by the bridge (check logs for `[action=policy_drop]`).
+- [ ] Post a message in the stream *mentioning* the bot (e.g., `@bot-name hello`).
+- [ ] Verify the message appears in the OpenClaw runtime.
+- [ ] Verify the bot responds in the same stream, optionally creating or continuing a topic.
+
+### 4. Deduplication & Recovery
+- [ ] Send a message to the bot (DM or stream).
+- [ ] Quickly restart the OpenClaw runtime.
+- [ ] Verify the bot does not process the same message twice upon restart.
+- [ ] Check logs for `[action=dedupe_hit]` or verify `ZulipDedupeStore` restored state from the filesystem.
+
+### 5. Attachment Handling
+- [ ] Send a DM to the bot containing an image attachment.
+- [ ] Verify the OpenClaw runtime receives the message and the attachment URL/metadata.
+
+### 6. Outbound Formatting
+- [ ] Trigger an OpenClaw action that sends formatted text (bold, italics, links, code blocks) to Zulip.
+- [ ] Verify the formatting renders correctly in the Zulip client.
+
+### 7. Queue Expiry & Re-registration
+- [ ] Leave the bridge running idle for an extended period (e.g., > 15 minutes).
+- [ ] Send a new message to the bot.
+- [ ] Verify the message is received and processed.
+- [ ] Check logs for `[action=queue_expired]` and `[action=queue_re_registered]` to ensure graceful recovery.
+
+## Troubleshooting
+
+-   **Queue churn:** If logs show constant re-registration, check network connectivity between the runtime and the Zulip server.
+-   **Missing messages:** Check the `ZULIP_EMAIL` configuration to ensure the bot is not filtering out its own messages. Verify DM/Group policy settings in the OpenClaw configuration.

--- a/test/smoke.test.ts
+++ b/test/smoke.test.ts
@@ -1,0 +1,68 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { formatZulipLog } from "../src/zulip/monitor-helpers.js";
+import { decidePolicy } from "../src/zulip/policy.js";
+
+test("smoke test formatZulipLog outputs expected string format", () => {
+  const result = formatZulipLog("test event", { accountId: "default", messageId: 123, stream: "general" });
+  assert.match(result, /test event/);
+  assert.match(result, /\[accountId=default/);
+  assert.match(result, /messageId=123/);
+  assert.match(result, /stream=general\]/);
+});
+
+test("smoke test decidePolicy enforces rules correctly", () => {
+  const resDM = decidePolicy({
+    kind: "dm",
+    senderId: "user_1",
+    senderName: "User One",
+    dmPolicy: "open",
+    groupPolicy: "open",
+    senderAllowedForCommands: true,
+    groupAllowedForCommands: false,
+    effectiveGroupAllowFromLength: 0,
+    shouldRequireMention: false,
+    wasMentioned: false,
+    isControlCommand: false,
+    commandAuthorized: false,
+    oncharTriggered: false,
+    canDetectMention: true,
+  });
+  assert.equal(resDM.shouldDrop, false);
+
+  const resGroupAllow = decidePolicy({
+    kind: "channel",
+    senderId: "user_2",
+    senderName: "User Two",
+    dmPolicy: "open",
+    groupPolicy: "allowlist",
+    senderAllowedForCommands: true,
+    groupAllowedForCommands: true,
+    effectiveGroupAllowFromLength: 1,
+    shouldRequireMention: true,
+    wasMentioned: true,
+    isControlCommand: false,
+    commandAuthorized: false,
+    oncharTriggered: false,
+    canDetectMention: true,
+  });
+  assert.equal(resGroupAllow.shouldDrop, false);
+
+  const resGroupDrop = decidePolicy({
+    kind: "channel",
+    senderId: "user_3",
+    senderName: "User Three",
+    dmPolicy: "open",
+    groupPolicy: "allowlist",
+    senderAllowedForCommands: true,
+    groupAllowedForCommands: false,
+    effectiveGroupAllowFromLength: 1,
+    shouldRequireMention: true,
+    wasMentioned: true,
+    isControlCommand: false,
+    commandAuthorized: false,
+    oncharTriggered: false,
+    canDetectMention: true,
+  });
+  assert.equal(resGroupDrop.shouldDrop, true);
+});


### PR DESCRIPTION
Resolves ZULIP-8. This adds a smoke-test.md document for testing the OpenClaw boundaries with Zulip. Adds a smoke.test.ts mocked integration tests to simulate bounds and limits. Adds logic in .github/workflows/ci.yml to protect lockfile drift and regression paths early by aborting when the local dir isn't clean.

---
*PR created automatically by Jules for task [15688386546800878531](https://jules.google.com/task/15688386546800878531) started by @niyazmft*