### PR TITLE
Fix Zulip sideload install and smoke-test docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,27 @@ The OpenClaw Zulip Bridge is a high-performance channel plugin for OpenClaw that
 
 ### Installation
 
-The Zulip bridge is typically installed as part of the OpenClaw plugin suite or via NPM:
+This repository is currently distributed as a **sideloaded local OpenClaw plugin**, not as a published npm package.
+
+Do **not** run:
 
 ```bash
 npm install @openclaw/zulip
 ```
+
+That package is not currently published to the npm registry, and this repo is marked `private`, which matches the current sideload-only distribution model.
+
+Instead, install the plugin from a local checkout/path:
+
+```bash
+openclaw plugins install /path/to/openclaw-zulip-bridge --link
+openclaw plugins enable zulip
+```
+
+Notes:
+- `--link` keeps the plugin connected to your working tree, which is useful for staging and sideload setups.
+- You can also install from a local path without `--link` if you want OpenClaw to copy the plugin into its managed extensions area.
+- This repo ships `openclaw.plugin.json`, so OpenClaw can discover it as a native local plugin.
 
 ### Basic Configuration
 
@@ -68,7 +84,7 @@ Detailed observability documentation is available in [docs/observability.md](doc
 
 ### Local Setup
 
-1. Install dependencies:
+1. Install dependencies for plugin development:
    ```bash
    npm install
    ```
@@ -77,6 +93,8 @@ Detailed observability documentation is available in [docs/observability.md](doc
    ```bash
    npm run check
    ```
+
+This `npm install` step is for **working on the plugin itself**, not for installing the plugin into OpenClaw from npm.
 
 ### Project Structure
 

--- a/docs/smoke-test.md
+++ b/docs/smoke-test.md
@@ -4,30 +4,36 @@ This document provides a manual smoke testing checklist for the OpenClaw Zulip B
 
 ## Prerequisites
 
-1.  A staging OpenClaw runtime environment.
-2.  A test Zulip organization (realm) where you have administrative access or can create bots.
-3.  A dedicated Zulip bot account for staging (`ZULIP_EMAIL`, `ZULIP_API_KEY`, `ZULIP_URL`).
-4.  At least two test user accounts in the Zulip organization.
-5.  A dedicated test stream (e.g., `#staging-test`).
+1. A staging OpenClaw runtime environment.
+2. A test Zulip organization (realm) where you have administrative access or can create bots.
+3. A dedicated Zulip bot account for staging (`ZULIP_EMAIL`, `ZULIP_API_KEY`, `ZULIP_URL`).
+4. At least two test user accounts in the Zulip organization.
+5. A dedicated test stream (e.g., `#staging-test`).
+6. A local checkout of this repository for sideload installation.
 
 ## Checklist
 
-### 1. Configuration & Startup
+### 1. Installation, Configuration & Startup
+- [ ] Install the plugin from a local checkout:
+  ```bash
+  openclaw plugins install /path/to/openclaw-zulip-bridge --link
+  openclaw plugins enable zulip
+  ```
 - [ ] Configure the bridge in the staging OpenClaw environment using environment variables (`ZULIP_EMAIL`, `ZULIP_API_KEY`, `ZULIP_URL`).
 - [ ] Start the OpenClaw runtime.
 - [ ] Verify the bridge initializes without errors in the logs.
-- [ ] Check logs for `[zulip] [action=queue_registered]` indicating a successful connection to the Zulip events API.
+- [ ] Check logs for `zulip queue registered` indicating a successful connection to the Zulip events API.
 
 ### 2. Direct Messages (DM) Policy
 - [ ] Send a DM from a test user to the bot.
 - [ ] Verify the message appears in the OpenClaw runtime.
 - [ ] Verify the bot responds correctly back to the user via DM.
-- [ ] Check logs for `[action=message_arrival]` and `[action=dispatched_to_openclaw]`.
+- [ ] Check logs for `zulip inbound arrival` and `zulip inbound dispatch`.
 
 ### 3. Stream/Group Policy (Mention Handling)
 - [ ] Add the bot to the test stream.
 - [ ] Post a message in the stream *without* mentioning the bot.
-- [ ] Verify the message is ignored by the bridge (check logs for `[action=policy_drop]`).
+- [ ] Verify the message is ignored by the bridge and confirm the drop is reflected in policy-related logs.
 - [ ] Post a message in the stream *mentioning* the bot (e.g., `@bot-name hello`).
 - [ ] Verify the message appears in the OpenClaw runtime.
 - [ ] Verify the bot responds in the same stream, optionally creating or continuing a topic.
@@ -36,7 +42,7 @@ This document provides a manual smoke testing checklist for the OpenClaw Zulip B
 - [ ] Send a message to the bot (DM or stream).
 - [ ] Quickly restart the OpenClaw runtime.
 - [ ] Verify the bot does not process the same message twice upon restart.
-- [ ] Check logs for `[action=dedupe_hit]` or verify `ZulipDedupeStore` restored state from the filesystem.
+- [ ] Check logs for `zulip inbound dedupe hit` or verify the dedupe store restored state from the filesystem.
 
 ### 5. Attachment Handling
 - [ ] Send a DM to the bot containing an image attachment.
@@ -50,9 +56,10 @@ This document provides a manual smoke testing checklist for the OpenClaw Zulip B
 - [ ] Leave the bridge running idle for an extended period (e.g., > 15 minutes).
 - [ ] Send a new message to the bot.
 - [ ] Verify the message is received and processed.
-- [ ] Check logs for `[action=queue_expired]` and `[action=queue_re_registered]` to ensure graceful recovery.
+- [ ] Check logs for `zulip queue expired` and a subsequent `zulip queue registered` to ensure graceful recovery.
 
 ## Troubleshooting
 
--   **Queue churn:** If logs show constant re-registration, check network connectivity between the runtime and the Zulip server.
--   **Missing messages:** Check the `ZULIP_EMAIL` configuration to ensure the bot is not filtering out its own messages. Verify DM/Group policy settings in the OpenClaw configuration.
+- **Queue churn:** If logs show constant re-registration, check network connectivity between the runtime and the Zulip server.
+- **Missing messages:** Check the `ZULIP_EMAIL` configuration to ensure the bot is not filtering out its own messages. Verify DM/Group policy settings in the OpenClaw configuration.
+- **Install confusion:** If someone tries `npm install @openclaw/zulip`, redirect them to the local sideload flow above; this repository is currently intended for sideload installation rather than npm registry distribution.

--- a/package.json
+++ b/package.json
@@ -21,9 +21,8 @@
       "order": 70
     },
     "install": {
-      "npmSpec": "@openclaw/zulip",
-      "localPath": "extensions/zulip",
-      "defaultChoice": "npm"
+      "localPath": ".",
+      "defaultChoice": "local"
     }
   },
   "private": true,


### PR DESCRIPTION
## Summary
- replace incorrect npm registry install guidance with local sideload instructions
- align OpenClaw install metadata with the repo's current sideload-only distribution model
- refresh smoke-test documentation to match current runtime event/log naming

## Why
This Zulip bridge is currently being used as a sideload extension, not a published npm package. The previous docs and install metadata suggested `npm install @openclaw/zulip`, which is misleading for the current release model and causes installation confusion.

## Changes
- `README.md`
  - remove npm-registry install guidance
  - add local sideload installation flow using `openclaw plugins install ... --link`
  - clarify that `npm install` is only for plugin development
- `package.json`
  - switch install default from `npm` to `local`
  - update local install path to the repo root
  - remove misleading `npmSpec` for the current sideload-only state
- `docs/smoke-test.md`
  - update install/setup steps for sideload usage
  - replace stale log markers with current event/log names

## Validation
- `npm ci --ignore-scripts`
- `npm run check`
- tests passed: `30/30`

## Notes
- This PR intentionally does not publish the package to npm.
- Local `main` in the working checkout was left untouched; this patch was prepared from the latest remote state on a separate branch.
