### PR TITLE
Sanitize error messages and mask PII in logs

### DIFF
--- a/src/channel.ts
+++ b/src/channel.ts
@@ -26,6 +26,7 @@ import {
   type ResolvedZulipAccount,
 } from "./zulip/accounts.js";
 import { normalizeZulipBaseUrl } from "./zulip/client.js";
+import { maskPII } from "./zulip/monitor-helpers.js";
 import { monitorZulipProvider } from "./zulip/monitor.js";
 import { probeZulip } from "./zulip/probe.js";
 import { sendMessageZulip } from "./zulip/send.js";
@@ -73,7 +74,7 @@ export const zulipPlugin: ChannelPlugin<ResolvedZulipAccount> = {
     idLabel: "zulipUserId",
     normalizeAllowEntry: (entry) => normalizeAllowEntry(entry),
     notifyApproval: async ({ id }) => {
-      console.log(`[zulip] User ${id} approved for pairing`);
+      console.log(`[zulip] User ${maskPII(id)} approved for pairing`);
     },
   },
   capabilities: {

--- a/src/zulip/client.ts
+++ b/src/zulip/client.ts
@@ -101,13 +101,17 @@ function delay(ms: number): Promise<void> {
 export async function readZulipError(res: Response): Promise<string> {
   const contentType = res.headers.get("content-type") ?? "";
   if (contentType.includes("application/json")) {
-    const data = (await res.json()) as ZulipApiResponse | undefined;
-    if (data?.msg) {
-      return data.msg;
+    try {
+      const data = (await res.json()) as ZulipApiResponse | undefined;
+      if (data?.msg) {
+        return data.msg;
+      }
+    } catch {
+      // ignore parse errors
     }
-    return JSON.stringify(data);
+    return "Zulip API error";
   }
-  return await res.text();
+  return "Zulip API error";
 }
 
 export function createZulipClient(params: {

--- a/src/zulip/monitor-helpers.ts
+++ b/src/zulip/monitor-helpers.ts
@@ -174,3 +174,51 @@ export function formatZulipLog(message: string, fields: Record<string, any>): st
     .map(([k, v]) => `${k}=${v}`);
   return parts.length > 0 ? `${message} [${parts.join(" ")}]` : message;
 }
+
+/**
+ * Masks sensitive information (PII) like emails and numeric IDs for safe logging.
+ */
+export function maskPII(value: string | number | undefined | null): string {
+  const str = String(value ?? "").trim();
+  if (!str) {
+    return "";
+  }
+
+  // Handle email
+  if (str.includes("@")) {
+    const [user, domain] = str.split("@");
+    if (user && domain) {
+      const maskedUser = user.length > 1 ? `${user[0]}***` : "***";
+      return `${maskedUser}@${domain}`;
+    }
+  }
+
+  // Handle numeric ID
+  if (/^\d+$/.test(str)) {
+    if (str.length <= 2) {
+      return "**";
+    }
+    if (str.length <= 5) {
+      return `${str[0]}***${str[str.length - 1]}`;
+    }
+    return `${str.slice(0, 2)}***${str.slice(-2)}`;
+  }
+
+  // Handle prefixed targets like user:email or stream:name
+  if (str.startsWith("user:")) {
+    return `user:${maskPII(str.slice(5))}`;
+  }
+  if (str.startsWith("stream:")) {
+    const rest = str.slice(7);
+    const parts = rest.split(/[:#/]/);
+    const streamName = parts[0];
+    const maskedStream = streamName.length > 2 ? `${streamName.slice(0, 2)}***` : "***";
+    return `stream:${maskedStream}${parts.length > 1 ? ":" + parts.slice(1).join(":") : ""}`;
+  }
+
+  // Fallback for other strings that might be sensitive
+  if (str.length <= 2) {
+    return "**";
+  }
+  return `${str.slice(0, 2)}***${str.slice(-2)}`;
+}

--- a/src/zulip/monitor.ts
+++ b/src/zulip/monitor.ts
@@ -41,6 +41,7 @@ import {
   formatInboundFromLabel,
   resolveThreadSessionKeys,
   formatZulipLog,
+  maskPII,
 } from "./monitor-helpers.js";
 import { ZulipDedupeStore } from "./dedupe-store.js";
 import { sendMessageZulip } from "./send.js";
@@ -305,7 +306,7 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
       formatZulipLog("zulip inbound arrival", {
         accountId: account.accountId,
         messageId,
-        senderId,
+        senderId: maskPII(senderId),
         kind,
         stream: streamName || streamId,
         topic,
@@ -455,7 +456,7 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
         runtime.log?.(
           formatZulipLog("zulip pairing request", {
             accountId: account.accountId,
-            senderId,
+            senderId: maskPII(senderId),
             created,
           }),
         );
@@ -479,7 +480,7 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
             runtime.error?.(
               formatZulipLog("zulip pairing reply failed", {
                 accountId: account.accountId,
-                senderId,
+                senderId: maskPII(senderId),
                 error: String(err),
               }),
             );
@@ -492,7 +493,7 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
               formatZulipLog(msg, {
                 accountId: account.accountId,
                 messageId,
-                senderId,
+                senderId: maskPII(senderId),
                 reason: policyResult.reason,
               }),
             ),
@@ -629,7 +630,7 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
       formatZulipLog("zulip inbound dispatch", {
         accountId: account.accountId,
         messageId,
-        senderId,
+        senderId: maskPII(senderId),
         from: ctxPayload.From,
         sessionKey,
         len: bodyText.length,
@@ -773,7 +774,7 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
         formatZulipLog("zulip reply failed", {
           accountId: account.accountId,
           messageId,
-          senderId,
+          senderId: maskPII(senderId),
           error: String(err),
         }),
       );

--- a/src/zulip/probe.ts
+++ b/src/zulip/probe.ts
@@ -52,7 +52,7 @@ export async function probeZulip(
       },
     };
   } catch (err) {
-    return { ok: false, error: err instanceof Error ? err.message : String(err) };
+    return { ok: false, error: "Zulip probe failed" };
   } finally {
     if (timeout) {
       clearTimeout(timeout);

--- a/src/zulip/send.ts
+++ b/src/zulip/send.ts
@@ -12,7 +12,7 @@ import {
   sendZulipStreamMessage,
   uploadZulipFile,
 } from "./client.js";
-import { formatZulipLog } from "./monitor-helpers.js";
+import { formatZulipLog, maskPII } from "./monitor-helpers.js";
 
 export type ZulipSendOpts = {
   apiKey?: string;
@@ -149,9 +149,9 @@ export async function sendMessageZulip(
   core.log?.(
     formatZulipLog("zulip outbound attempt", {
       accountId: account.accountId,
-      target: to,
+      target: maskPII(to),
       kind,
-      stream,
+      stream: stream ? maskPII(stream) : undefined,
       topic,
       sessionKey: opts.sessionKey,
       hasMedia: Boolean(opts.mediaUrl),
@@ -239,9 +239,9 @@ export async function sendMessageZulip(
     formatZulipLog("zulip outbound success", {
       accountId: account.accountId,
       messageId,
-      target: to,
+      target: maskPII(to),
       kind,
-      stream,
+      stream: stream ? maskPII(stream) : undefined,
       topic: target.kind === "stream" ? target.topic || opts.topic || DEFAULT_TOPIC : undefined,
       sessionKey: opts.sessionKey,
     }),


### PR DESCRIPTION
Implemented security remediations to sanitize error messages and mask PII (emails, numeric IDs) in logs across the Zulip channel plugin. introduced a centralized `maskPII` helper and applied it to inbound monitoring, outbound sending, and pairing flows. genericized error reporting in connection probes and API error handling to prevent internal detail leakage.

Fixes #21

---
*PR created automatically by Jules for task [12366387524966775550](https://jules.google.com/task/12366387524966775550) started by @niyazmft*