### PR TITLE
Remove remaining npm-install messaging from Zulip end-user onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,20 +17,13 @@ The OpenClaw Zulip Bridge is a high-performance channel plugin for OpenClaw that
 
 ### Installation
 
-This repository is currently distributed as a **sideloaded local OpenClaw plugin**, not as a published npm package.
+This repository is designed for **sideloaded local installation** as an OpenClaw plugin. It is not currently distributed via the npm registry.
 
-Do **not** run:
-
-```bash
-npm install @openclaw/zulip
-```
-
-That package is not currently published to the npm registry, and this repo is marked `private`, which matches the current sideload-only distribution model.
-
-Instead, install the plugin from a local checkout/path:
+To install the bridge, clone this repository and use the OpenClaw CLI to install it from your local path:
 
 ```bash
-openclaw plugins install "$HOME/.openclaw/workspace/specialists/tech/openclaw-zulip-bridge" --link
+# Replace with the actual path to your local checkout
+openclaw plugins install /path/to/openclaw-zulip-bridge --link
 openclaw plugins enable zulip
 ```
 
@@ -94,7 +87,7 @@ Detailed observability documentation is available in [docs/observability.md](doc
    npm run check
    ```
 
-This `npm install` step is for **working on the plugin itself**, not for installing the plugin into OpenClaw from npm.
+This `npm install` step is for **contributing to or testing the plugin codebase**; it is not the command for installing the plugin into your OpenClaw runtime.
 
 ### Project Structure
 

--- a/docs/smoke-test.md
+++ b/docs/smoke-test.md
@@ -62,4 +62,4 @@ This document provides a manual smoke testing checklist for the OpenClaw Zulip B
 
 - **Queue churn:** If logs show constant re-registration, check network connectivity between the runtime and the Zulip server.
 - **Missing messages:** Check the `ZULIP_EMAIL` configuration to ensure the bot is not filtering out its own messages. Verify DM/Group policy settings in the OpenClaw configuration.
-- **Install confusion:** If someone tries `npm install @openclaw/zulip`, redirect them to the local sideload flow above; this repository is currently intended for sideload installation rather than npm registry distribution.
+- **Install confusion:** If the plugin is not recognized by OpenClaw, verify that the local path provided to `openclaw plugins install` is correct and that the plugin was successfully enabled with `openclaw plugins enable zulip`.


### PR DESCRIPTION
This PR removes misleading 'npm install @openclaw/zulip' instructions from the README and documentation, replacing them with the correct local sideload/plugin install commands. It also clarifies that 'npm install' is only intended for development and contributing to the plugin codebase.

Fixes #23

---
*PR created automatically by Jules for task [12408838351288083186](https://jules.google.com/task/12408838351288083186) started by @niyazmft*