### PR TITLE
Audit Zulip extension drift and define migration path

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,14 @@ Restart OpenClaw to apply the changes.
 
 Success is confirmed when the bot is both **registered** in logs and **responding** to messages.
 
+### Parity & Verification
+
+To verify that the bridge is running the latest repository version (and not a legacy installation), check for these markers:
+
+1.  **Log Markers**: Look for the log entry `zulip queue registered [accountId=... queueId=... lastEventId=...]`. Legacy versions likely lacked this structured log.
+2.  **PII Masking**: Send a message to the bot and observe the logs. The latest version implements `maskPII` for security, so logs should show masked values like `senderId: user:********` instead of full email addresses or numeric IDs.
+3.  **Durable State**: Check for persistent JSON files in your temporary directory (`os.tmpdir()`) with the pattern `openclaw-zulip-*.json`. These files store queue metadata and deduplication state, which was not present in legacy versions.
+
 ## Configure Zulip in openclaw.json
 
 While environment variables are great for secrets in the default account, you can also configure Zulip directly in your `openclaw.json` (or `openclaw.config.json`). This is required for multi-account setups or when using advanced policies.

--- a/docs/drift-matrix.md
+++ b/docs/drift-matrix.md
@@ -1,0 +1,20 @@
+# Zulip Bridge Drift Matrix
+
+This matrix compares the legacy installed state of the Zulip bridge against the current repository state (`main`).
+
+| Feature / Aspect | Legacy Behavior (Installed) | Repo Behavior (Current) | Category | Impact |
+| :--- | :--- | :--- | :--- | :--- |
+| **Event Queue** | In-memory only; loses state on restart. | Persistent `queueId` and `lastEventId` in `os.tmpdir()`. | Runtime | High: Prevents missed messages during restarts. |
+| **Deduplication** | In-memory only; risk of replay on restart. | Durable `ZulipDedupeStore` with filesystem persistence. | Runtime | High: Prevents duplicate message processing. |
+| **Secret Handling** | Plaintext `apiKey` and `email` in `openclaw.json`. | Supports environment variables (`ZULIP_API_KEY`, etc.) with precedence. | Runtime | Critical: Security improvement, prevents secret leakage. |
+| **Traffic Policies** | Fragile or underspecified DM/Stream routing. | Explicit `dmPolicy` (pairing, allowlist, open) and `groupPolicy`. | Runtime | High: Predictable and secure message routing. |
+| **Observability** | Minimal logs; potential PII leakage. | Standardized logs with PII masking (`maskPII`) and stable identifiers. | Runtime | Medium: Safer and easier troubleshooting. |
+| **Multi-account** | Single account support. | Explicit `accounts` map support in config (no env-var fallback for secondary). | Runtime | Medium: Enables multi-realm connectivity. |
+| **Response Behavior** | Basic message sending. | Reaction-based status indicators and `blockStreaming` support. | Runtime | Medium: Improved user feedback and performance. |
+| **Testing** | Limited or no local tests. | Full suite of unit and smoke tests (`test/*.test.ts`). | Dev-only | High: Ensures regression-free development. |
+| **Documentation** | Minimal setup instructions. | Comprehensive `README.md`, `docs/config.md`, and `docs/smoke-test.md`. | Dev-only | Medium: Faster onboarding and clearer configuration. |
+
+## Runtime vs. Dev-only Differences
+
+- **Runtime-relevant**: Changes to logic in `src/zulip/` (queue management, deduplication, policy enforcement, PII masking) and the configuration schema. These directly affect how the bridge behaves and its security posture.
+- **Dev-only**: Tests, documentation, and internal build tooling. While these don't change the execution logic, they are essential for long-term maintenance and reliable deployment.

--- a/docs/migration-path.md
+++ b/docs/migration-path.md
@@ -1,0 +1,68 @@
+# Zulip Bridge Migration & Alignment Path
+
+This guide outlines the steps for migrating from a legacy Zulip bridge installation to the current repository state, ensuring parity between your running code and the repository source.
+
+## 1. Backup Current Configuration
+
+Before making changes, back up your current OpenClaw configuration file (usually `openclaw.json` or `openclaw.config.json`).
+
+```bash
+cp ~/.openclaw/openclaw.json ~/.openclaw/openclaw.json.bak
+```
+
+## 2. Migrate Secrets to Environment Variables (Recommended)
+
+To improve security and take advantage of the repository's improved secret handling, move your Zulip credentials out of the configuration file and into environment variables.
+
+**Remove these from `openclaw.json`:**
+- `apiKey`
+- `email`
+- `url` (or `site`, `realm`)
+
+**Set them in your environment (e.g., `.bashrc`, `.env`, or systemd service):**
+```bash
+export ZULIP_EMAIL="bot@example.com"
+export ZULIP_API_KEY="your-api-key"
+export ZULIP_URL="https://chat.example.com"
+```
+
+## 3. Uninstall Legacy Extension
+
+If you have a legacy extension installed as a standalone package or older linked version, uninstall it to ensure a clean slate.
+
+```bash
+openclaw plugins uninstall zulip
+```
+
+## 4. Install Current Repo as a Linked Plugin
+
+The most reliable way to maintain parity is to install the plugin directly from your local repository checkout using the `--link` flag. This creates a symbolic link, ensuring any changes in the repository are immediately reflected in the running extension.
+
+```bash
+cd ~/.openclaw/workspace/specialists/tech/openclaw-zulip-bridge # Path to your local repo
+openclaw plugins install ./ --link
+openclaw plugins enable zulip
+```
+
+## 5. Verify Active Plugin Version
+
+After restarting OpenClaw, verify that the current version is active by checking the logs for new patterns:
+
+- **Queue Registration**: Look for the log marker `zulip queue registered [accountId=...]`. Legacy versions likely lacked this structured log.
+- **PII Masking**: Send a message to the bot. Logs should show `senderId: user:********` or similar masked values instead of full emails or IDs.
+- **Persistent Files**: Check for the existence of state files in your temporary directory:
+  ```bash
+  ls /tmp/openclaw-zulip-*.json
+  ```
+
+## 6. Restart OpenClaw
+
+Restart your OpenClaw instance to apply the changes.
+
+| Environment | Restart Command |
+| --- | --- |
+| **Systemd** | `systemctl restart openclaw` |
+| **PM2** | `pm2 restart openclaw` |
+| **Manual/CLI** | `Ctrl+C` then restart (e.g., `openclaw start`) |
+
+Following this path ensures that the repository code is the live source of truth for your Zulip bridge, resolving drift issues and aligning with the latest robustness improvements.


### PR DESCRIPTION
Audit the differences between the live Zulip extension and the repo, and define a clear migration/parity path.

Fixes #29

---
*PR created automatically by Jules for task [2854306411636035037](https://jules.google.com/task/2854306411636035037) started by @niyazmft*