### PR TITLE
chore: bump version to 2026.3.30

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@openclaw/zulip",
-  "version": "2026.3.29",
+  "version": "2026.3.30",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openclaw/zulip",
-      "version": "2026.3.29",
+      "version": "2026.3.30",
       "dependencies": {
         "zod": "^4.3.6",
         "zulip-js": "^2.1.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/zulip",
-  "version": "2026.3.29",
+  "version": "2026.3.30",
   "description": "OpenClaw Zulip channel plugin",
   "type": "module",
   "dependencies": {


### PR DESCRIPTION
Bump version to 2026.3.30 to include recent improvements:
- Web UI compatibility fixes (simplified config schema)
- Setup SDK alignment
- Branding updates (new chat bubble icon)
- Updated documentation and setup entry points