### PR TITLE
chore: bump version to 2026.3.31

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@openclaw/zulip",
-  "version": "2026.3.30",
+  "version": "2026.3.31",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openclaw/zulip",
-      "version": "2026.3.30",
+      "version": "2026.3.31",
       "dependencies": {
         "zod": "^4.3.6",
         "zulip-js": "^2.1.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/zulip",
-  "version": "2026.3.30",
+  "version": "2026.3.31",
   "description": "OpenClaw Zulip channel plugin",
   "type": "module",
   "dependencies": {


### PR DESCRIPTION
Synchronized release to finalize branding and ensure GitHub/ClawHub parity.