### PR TITLE
Fix Web UI setup 'Unsupported type' fallback

### DIFF
--- a/src/setup-core.ts
+++ b/src/setup-core.ts
@@ -29,8 +29,8 @@ export const zulipSetupAdapter: ChannelSetupAdapter = createPatchedAccountSetupA
     },
   }),
   buildPatch: (input) => {
-    const apiKey = input.token ?? input.botToken;
-    const email = input.tokenFile?.trim();
+    const apiKey = input.apiKey ?? input.token ?? input.botToken;
+    const email = (input.email ?? input.tokenFile)?.trim();
     const baseUrl = normalizeZulipBaseUrl(input.httpUrl);
     const dmPolicy = input.dmPolicy ?? "pairing";
     const streaming = input.streaming !== "false";

--- a/src/setup-surface.ts
+++ b/src/setup-surface.ts
@@ -81,36 +81,26 @@ export const zulipSetupWizard: ChannelSetupWizard = {
     },
     apply: ({ cfg }) => cfg,
   },
-  credentials: [
-    {
-      inputKey: "token",
-      providerHint: channel,
-      credentialLabel: "api key",
-      preferredEnvVar: "ZULIP_API_KEY",
-      envPrompt: "ZULIP_API_KEY + ZULIP_EMAIL + ZULIP_URL detected. Use env vars?",
-      keepPrompt: "Zulip API key already configured. Keep it?",
-      inputPrompt: "Enter Zulip API key",
-      allowEnv: ({ accountId, cfg }) => resolveSetupAccountId(cfg, accountId) === DEFAULT_ACCOUNT_ID,
-      inspect: ({ cfg, accountId }) => {
-        const resolved = resolveZulipAccount({
-          cfg,
-          accountId: resolveSetupAccountId(cfg, accountId),
-        });
-        return {
-          accountConfigured: isZulipConfigured(resolved),
-          hasConfiguredValue: Boolean(resolved.config.apiKey?.trim()),
-          resolvedValue: resolved.apiKey?.trim() || undefined,
-          envValue:
-            resolveSetupAccountId(cfg, accountId) === DEFAULT_ACCOUNT_ID
-              ? process.env.ZULIP_API_KEY?.trim() || undefined
-              : undefined,
-        };
-      },
-    },
-  ],
   textInputs: [
     {
-      inputKey: "tokenFile",
+      inputKey: "apiKey",
+      message: "Enter Zulip API key",
+      confirmCurrentValue: false,
+      currentValue: ({ cfg, accountId }) =>
+        resolveZulipAccount({ cfg, accountId: resolveSetupAccountId(cfg, accountId) }).apiKey ??
+        (resolveSetupAccountId(cfg, accountId) === DEFAULT_ACCOUNT_ID
+          ? process.env.ZULIP_API_KEY?.trim()
+          : undefined),
+      initialValue: ({ cfg, accountId }) =>
+        resolveZulipAccount({ cfg, accountId: resolveSetupAccountId(cfg, accountId) }).apiKey ??
+        (resolveSetupAccountId(cfg, accountId) === DEFAULT_ACCOUNT_ID
+          ? process.env.ZULIP_API_KEY?.trim()
+          : undefined),
+      validate: ({ value }) => (value?.trim() ? undefined : "Zulip API key is required."),
+      normalizeValue: ({ value }) => value.trim(),
+    },
+    {
+      inputKey: "email",
       message: "Enter Zulip bot email",
       confirmCurrentValue: false,
       currentValue: ({ cfg, accountId }) =>


### PR DESCRIPTION
This PR fixes the issue where the Zulip plugin's setup surface caused the OpenClaw Web UI to fall back to "Raw mode" with an "Unsupported type" error.

The root cause was the use of a non-standard `credentials` array in the `ChannelSetupWizard` definition. I've refactored the surface to use the standard `textInputs` array and renamed the input keys to better match Zulip's nomenclature (`apiKey` and `email`).

Existing configurations remain compatible as the setup adapter now handles both the old and new field names.

Fixes #116

---
*PR created automatically by Jules for task [3681398293097761915](https://jules.google.com/task/3681398293097761915) started by @niyazmft*