### PR TITLE
Clean up minor Zulip repo hygiene issues

### DIFF
--- a/src/zulip/client.ts
+++ b/src/zulip/client.ts
@@ -1,5 +1,5 @@
 import { readSafeLocalFile } from "./fs-utils.js";
-import { formatZulipLog } from "./monitor-helpers.js";
+import { formatZulipLog, delay } from "./monitor-helpers.js";
 
 export type ZulipClient = {
   baseUrl: string;
@@ -103,10 +103,6 @@ function resolveRetryAfterMs(res: Response): number | undefined {
     return Math.max(0, dateMs - Date.now());
   }
   return undefined;
-}
-
-function delay(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 export async function readZulipError(res: Response): Promise<string> {

--- a/src/zulip/monitor-helpers.ts
+++ b/src/zulip/monitor-helpers.ts
@@ -1,21 +1,3 @@
-import type { OpenClawConfig } from "openclaw/plugin-sdk";
-import type WebSocket from "ws";
-import { Buffer } from "node:buffer";
-
-export type ResponsePrefixContext = {
-  model?: string;
-  modelFull?: string;
-  provider?: string;
-  thinkingLevel?: string;
-  identityName?: string;
-};
-
-export function extractShortModelName(fullModel: string): string {
-  const slash = fullModel.lastIndexOf("/");
-  const modelPart = slash >= 0 ? fullModel.slice(slash + 1) : fullModel;
-  return modelPart.replace(/-\d{8}$/, "").replace(/-latest$/, "");
-}
-
 export function formatInboundFromLabel(params: {
   isGroup: boolean;
   groupLabel?: string;
@@ -36,116 +18,6 @@ export function formatInboundFromLabel(params: {
     return directLabel;
   }
   return `${directLabel} id:${directId}`;
-}
-
-type DedupeCache = {
-  check: (key: string | undefined | null, now?: number) => boolean;
-};
-
-export function createDedupeCache(options: { ttlMs: number; maxSize: number }): DedupeCache {
-  const ttlMs = Math.max(0, options.ttlMs);
-  const maxSize = Math.max(0, Math.floor(options.maxSize));
-  const cache = new Map<string, number>();
-
-  const touch = (key: string, now: number) => {
-    cache.delete(key);
-    cache.set(key, now);
-  };
-
-  const prune = (now: number) => {
-    const cutoff = ttlMs > 0 ? now - ttlMs : undefined;
-    if (cutoff !== undefined) {
-      for (const [entryKey, entryTs] of cache) {
-        if (entryTs < cutoff) {
-          cache.delete(entryKey);
-        }
-      }
-    }
-    if (maxSize <= 0) {
-      cache.clear();
-      return;
-    }
-    while (cache.size > maxSize) {
-      const oldestKey = cache.keys().next().value as string | undefined;
-      if (!oldestKey) {
-        break;
-      }
-      cache.delete(oldestKey);
-    }
-  };
-
-  return {
-    check: (key, now = Date.now()) => {
-      if (!key) {
-        return false;
-      }
-      const existing = cache.get(key);
-      if (existing !== undefined && (ttlMs <= 0 || now - existing < ttlMs)) {
-        touch(key, now);
-        return true;
-      }
-      touch(key, now);
-      prune(now);
-      return false;
-    },
-  };
-}
-
-export function rawDataToString(
-  data: WebSocket.RawData,
-  encoding: BufferEncoding = "utf8",
-): string {
-  if (typeof data === "string") {
-    return data;
-  }
-  if (Buffer.isBuffer(data)) {
-    return data.toString(encoding);
-  }
-  if (Array.isArray(data)) {
-    return Buffer.concat(data).toString(encoding);
-  }
-  if (data instanceof ArrayBuffer) {
-    return Buffer.from(data).toString(encoding);
-  }
-  return Buffer.from(String(data)).toString(encoding);
-}
-
-function normalizeAgentId(value: string | undefined | null): string {
-  const trimmed = (value ?? "").trim();
-  if (!trimmed) {
-    return "main";
-  }
-  if (/^[a-z0-9][a-z0-9_-]{0,63}$/i.test(trimmed)) {
-    return trimmed;
-  }
-  return (
-    trimmed
-      .toLowerCase()
-      .replace(/[^a-z0-9_-]+/g, "-")
-      .replace(/^-+/, "")
-      .replace(/-+$/, "")
-      .slice(0, 64) || "main"
-  );
-}
-
-type AgentEntry = NonNullable<NonNullable<OpenClawConfig["agents"]>["list"]>[number];
-
-function listAgents(cfg: OpenClawConfig): AgentEntry[] {
-  const list = cfg.agents?.list;
-  if (!Array.isArray(list)) {
-    return [];
-  }
-  return list.filter((entry): entry is AgentEntry => Boolean(entry && typeof entry === "object"));
-}
-
-function resolveAgentEntry(cfg: OpenClawConfig, agentId: string): AgentEntry | undefined {
-  const id = normalizeAgentId(agentId);
-  return listAgents(cfg).find((entry) => normalizeAgentId(entry.id) === id);
-}
-
-export function resolveIdentityName(cfg: OpenClawConfig, agentId: string): string | undefined {
-  const entry = resolveAgentEntry(cfg, agentId);
-  return entry?.identity?.name?.trim() || undefined;
 }
 
 export function resolveThreadSessionKeys(params: {
@@ -221,4 +93,11 @@ export function maskPII(value: string | number | undefined | null): string {
     return "**";
   }
   return `${str.slice(0, 2)}***${str.slice(-2)}`;
+}
+
+/**
+ * Delays execution for a given number of milliseconds.
+ */
+export function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }

--- a/src/zulip/monitor.ts
+++ b/src/zulip/monitor.ts
@@ -13,6 +13,7 @@ import {
   resolveThreadSessionKeys,
   formatZulipLog,
   maskPII,
+  delay,
 } from "./monitor-helpers.js";
 import { ZulipDedupeStore } from "./dedupe-store.js";
 import { sendMessageZulip } from "./send.js";
@@ -32,7 +33,7 @@ import {
 import { downloadAttachments } from "./media-utils.js";
 import { addReactionSafe, removeReactionSafe } from "./reactions.js";
 import { initializeZulipMonitor } from "./bootstrap.js";
-import { pollOnce, delay } from "./polling.js";
+import { pollOnce } from "./polling.js";
 import { dispatchZulipReply } from "./reply-handler.js";
 
 export type MonitorZulipOpts = {

--- a/src/zulip/polling.ts
+++ b/src/zulip/polling.ts
@@ -1,16 +1,9 @@
 import type { PluginRuntime } from "openclaw/plugin-sdk";
 import type { ZulipMessage } from "./client.js";
 import { getZulipEventsWithRetry } from "./client.js";
-import { formatZulipLog } from "./monitor-helpers.js";
+import { formatZulipLog, delay } from "./monitor-helpers.js";
 import { ZulipQueueManager } from "./queue-manager.js";
 import type { MonitorZulipOpts } from "./monitor.js";
-
-/**
- * Delays execution for a given number of milliseconds.
- */
-export function delay(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
 
 /**
  * Performs a single polling cycle for Zulip events.


### PR DESCRIPTION
This PR addresses minor repository hygiene issues in the Zulip plugin. It consolidates the `delay` helper function into a single shared utility in `monitor-helpers.ts`, removing duplicates from `client.ts` and `polling.ts`. It also removes several unused functions and types from `monitor-helpers.ts` that were left over from previous iterations, such as `extractShortModelName`, `rawDataToString`, and agent-related resolution helpers. These changes are low-risk and do not alter any product behavior. All existing tests pass.

Fixes #117

---
*PR created automatically by Jules for task [7761804509886680997](https://jules.google.com/task/7761804509886680997) started by @niyazmft*