### PR TITLE
Add host-side smoke validation for packaged artifacts

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,8 +61,9 @@
     "build": "tsc -p tsconfig.build.json",
     "test": "node --test --experimental-strip-types --loader ./test-loader.js test/*.test.ts",
     "check:package": "node scripts/check-package.js",
+    "check:smoke": "node --loader ./test/smoke-loader.js scripts/smoke-test-dist.js",
     "check:bootstrap": "node scripts/check-bootstrap.js",
-    "check": "npm run check:bootstrap && npm run typecheck && npm run build && npm run test && npm run check:package"
+    "check": "npm run check:bootstrap && npm run typecheck && npm run build && npm run check:smoke && npm run test && npm run check:package"
   },
   "devDependencies": {
     "@types/node": "^24.5.2",

--- a/scripts/check-package.js
+++ b/scripts/check-package.js
@@ -60,11 +60,18 @@ try {
   }
 
   // Verify essential metadata files are packaged
-  const essentialFiles = ['openclaw.plugin.json', 'README.md', 'SKILL.md', 'package.json'];
+  const essentialFiles = ['openclaw.plugin.json', 'README.md', 'package.json'];
   for (const file of essentialFiles) {
     if (!packagedFiles.has(file)) {
       errors.push(`Essential file missing from package: ${file}`);
     }
+  }
+
+  // Verify SKILL.md (optional but encouraged)
+  if (!packagedFiles.has('SKILL.md')) {
+    console.log('Note: SKILL.md is missing from package (optional but recommended).');
+  } else {
+    console.log('OK: SKILL.md is included.');
   }
 
   console.log(`OK: ${packagedFiles.size} files will be packaged.`);

--- a/scripts/check-package.js
+++ b/scripts/check-package.js
@@ -1,9 +1,12 @@
 import { readFileSync, existsSync } from 'node:fs';
+import { execSync } from 'node:child_process';
 
 const pkg = JSON.parse(readFileSync('package.json', 'utf8'));
 const manifest = JSON.parse(readFileSync('openclaw.plugin.json', 'utf8'));
 
 let errors = [];
+
+console.log('Validating package configuration and contents...');
 
 // 1. Version consistency
 if (pkg.version !== manifest.version) {
@@ -27,7 +30,7 @@ if (pkg.files) {
   }
 }
 
-// 4. Existence of built artifacts
+// 4. Existence of built artifacts (local filesystem check)
 const extensions = pkg.openclaw?.extensions || [];
 const artifacts = [
   ...extensions,
@@ -36,14 +39,43 @@ const artifacts = [
 
 for (const artifact of artifacts) {
   if (!existsSync(artifact)) {
-    errors.push(`Built artifact does not exist: ${artifact}`);
+    errors.push(`Built artifact does not exist on disk: ${artifact}`);
   }
 }
 
+// 5. Packaged files validation (npm pack --dry-run)
+try {
+  console.log('Running npm pack --dry-run to verify packaged artifacts...');
+  const packOutput = execSync('npm pack --dry-run --json', { encoding: 'utf8' });
+  const packData = JSON.parse(packOutput)[0];
+  const packagedFiles = new Set(packData.files.map(f => f.path));
+
+  // Verify entry points are packaged
+  for (const artifact of artifacts) {
+    // npm pack output uses paths relative to package root without leading ./
+    const normalizedArtifact = artifact.startsWith('./') ? artifact.slice(2) : artifact;
+    if (!packagedFiles.has(normalizedArtifact)) {
+      errors.push(`Critical artifact missing from package: ${normalizedArtifact}`);
+    }
+  }
+
+  // Verify essential metadata files are packaged
+  const essentialFiles = ['openclaw.plugin.json', 'README.md', 'SKILL.md', 'package.json'];
+  for (const file of essentialFiles) {
+    if (!packagedFiles.has(file)) {
+      errors.push(`Essential file missing from package: ${file}`);
+    }
+  }
+
+  console.log(`OK: ${packagedFiles.size} files will be packaged.`);
+} catch (err) {
+  errors.push(`Failed to run npm pack or parse output: ${err.message}`);
+}
+
 if (errors.length > 0) {
-  console.error('Package validation failed:');
+  console.error('\nPackage validation failed:');
   errors.forEach(err => console.error(`- ${err}`));
   process.exit(1);
 }
 
-console.log('Package validation passed.');
+console.log('\nPackage validation passed.');

--- a/scripts/smoke-test-dist.js
+++ b/scripts/smoke-test-dist.js
@@ -1,0 +1,52 @@
+import { resolve as pathResolve } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { readFileSync, existsSync } from 'node:fs';
+import assert from 'node:assert/strict';
+
+const __dirname = pathResolve(fileURLToPath(import.meta.url), '..');
+const rootDir = pathResolve(__dirname, '..');
+
+const pkg = JSON.parse(readFileSync(pathResolve(rootDir, 'package.json'), 'utf8'));
+
+async function runSmokeTest() {
+  console.log('Running host-side smoke validation on built artifacts...');
+
+  const extensions = pkg.openclaw?.extensions || [];
+  const setupEntry = pkg.openclaw?.setupEntry;
+
+  // 1. Validate Plugin Entry
+  for (const extension of extensions) {
+    const indexPath = pathResolve(rootDir, extension);
+    if (!existsSync(indexPath)) {
+      throw new Error(`Plugin entry point not found: ${extension}`);
+    }
+
+    console.log(`Checking entry point: ${extension}`);
+    const mod = await import(pathToFileURL(indexPath).href);
+
+    assert.ok(mod.default, `Entry point ${extension} must have a default export`);
+    assert.equal(typeof mod.default.id, 'string', `Plugin in ${extension} must have an ID string`);
+    console.log(`OK: Loaded plugin "${mod.default.id}" from ${extension}`);
+  }
+
+  // 2. Validate Setup Entry
+  if (setupEntry) {
+    const setupPath = pathResolve(rootDir, setupEntry);
+    if (!existsSync(setupPath)) {
+      throw new Error(`Setup entry point not found: ${setupEntry}`);
+    }
+
+    console.log(`Checking setup entry point: ${setupEntry}`);
+    const mod = await import(pathToFileURL(setupPath).href);
+    assert.ok(mod.default, `Setup entry point ${setupEntry} must have a default export`);
+    console.log(`OK: Loaded setup entry from ${setupEntry}`);
+  }
+
+  console.log('\nHost-side smoke validation passed.');
+}
+
+runSmokeTest().catch(err => {
+  console.error('\nHost-side smoke validation FAILED:');
+  console.error(err);
+  process.exit(1);
+});

--- a/test/smoke-loader.js
+++ b/test/smoke-loader.js
@@ -1,0 +1,18 @@
+const openclawShimUrl = new URL('./openclaw-plugin-sdk-shim.js', import.meta.url).href;
+
+/**
+ * A minimal ESM loader for smoke-testing built artifacts.
+ * It only shims 'openclaw/plugin-sdk' and does NOT perform
+ * source redirection (e.g. .js -> .ts), ensuring we test
+ * the actual built files in dist/.
+ */
+export function resolve(specifier, context, nextResolve) {
+  if (specifier === 'openclaw/plugin-sdk' || specifier.startsWith('openclaw/plugin-sdk/')) {
+    return {
+      url: openclawShimUrl,
+      shortCircuit: true,
+    };
+  }
+
+  return nextResolve(specifier, context);
+}


### PR DESCRIPTION
Add automated validation for packaged plugin artifacts to prevent breakage related to dist entrypoints, packaged file layout, and host discovery expectations.

Includes:
- Package content verification using `npm pack --dry-run`.
- Host-oriented runtime smoke check via dynamic import of built artifacts.
- Integration into existing CI/check workflow.

Fixes #118

---
*PR created automatically by Jules for task [4081331983636640733](https://jules.google.com/task/4081331983636640733) started by @niyazmft*