### PR TITLE
Audit and tighten Zulip runtime logging for sensitive-data exposure

### DIFF
--- a/src/channel.ts
+++ b/src/channel.ts
@@ -168,8 +168,8 @@ export const zulipPlugin = createChatChannelPlugin<ResolvedZulipAccount>({
       }
       return await probeZulip(baseUrl, email, apiKey, timeoutMs);
     },
-    buildAccountSnapshot: ({ account, runtime, probe }) =>
-      ({
+    buildAccountSnapshot: ({ account, runtime, probe }) => {
+      const snapshot: ChannelAccountSnapshot = {
         accountId: account.accountId,
         name: account.name,
         enabled: account.enabled,
@@ -184,10 +184,17 @@ export const zulipPlugin = createChatChannelPlugin<ResolvedZulipAccount>({
         lastStartAt: runtime?.lastStartAt ?? null,
         lastStopAt: runtime?.lastStopAt ?? null,
         lastError: runtime?.lastError ?? null,
-        probe,
+        probe: probe
+          ? {
+              ...probe,
+              email: probe.email ? maskPII(probe.email) : undefined,
+            }
+          : undefined,
         lastInboundAt: runtime?.lastInboundAt ?? null,
         lastOutboundAt: runtime?.lastOutboundAt ?? null,
-      }) as ChannelAccountSnapshot,
+      };
+      return snapshot;
+    },
   },
   gateway: {
     startAccount: async (ctx) => {

--- a/src/zulip/media-utils.ts
+++ b/src/zulip/media-utils.ts
@@ -4,7 +4,7 @@ import path from "node:path";
 import type { PluginRuntime } from "openclaw/plugin-sdk";
 import { getZulipRuntime } from "../runtime.js";
 import { downloadZulipUpload } from "./uploads.js";
-import { formatZulipLog } from "./monitor-helpers.js";
+import { formatZulipLog, maskPII } from "./monitor-helpers.js";
 
 const checkedMediaDirs = new Set<string>();
 
@@ -84,7 +84,7 @@ export async function downloadAttachments(params: {
           formatZulipLog("zulip attachment download failed", {
             accountId,
             messageId,
-            url: uploadUrl,
+            url: maskPII(uploadUrl),
             error: String(err),
           }),
         );

--- a/src/zulip/monitor-helpers.ts
+++ b/src/zulip/monitor-helpers.ts
@@ -56,16 +56,30 @@ export function maskPII(value: string | number | undefined | null): string {
     return "";
   }
 
-  // Handle prefixed targets like user:email or stream:name
+  // Handle prefixed targets like user:email, dm:email, zulip:email, or stream:name
   if (str.startsWith("user:")) {
     return `user:${maskPII(str.slice(5))}`;
+  }
+  if (str.startsWith("dm:")) {
+    return `dm:${maskPII(str.slice(3))}`;
+  }
+  if (str.startsWith("zulip:")) {
+    const rest = str.slice(6);
+    if (rest.startsWith("channel:")) {
+      return `zulip:channel:${maskPII(rest.slice(8))}`;
+    }
+    return `zulip:${maskPII(rest)}`;
   }
   if (str.startsWith("stream:")) {
     const rest = str.slice(7);
     const parts = rest.split(/[:#/]/);
     const streamName = parts[0];
     const maskedStream = streamName.length > 2 ? `${streamName.slice(0, 2)}***` : "***";
-    return `stream:${maskedStream}${parts.length > 1 ? ":" + parts.slice(1).join(":") : ""}`;
+    if (parts.length > 1) {
+      const topic = parts.slice(1).join(":");
+      return `stream:${maskedStream}:${maskPII(topic)}`;
+    }
+    return `stream:${maskedStream}`;
   }
 
   // Handle email

--- a/src/zulip/monitor.ts
+++ b/src/zulip/monitor.ts
@@ -135,8 +135,8 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
           messageId,
           senderId: maskPII(senderId),
           kind,
-          stream: streamName || streamId,
-          topic,
+          stream: maskPII(streamName || streamId),
+          topic: topic ? maskPII(topic) : undefined,
         }),
       );
 
@@ -439,10 +439,11 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
           accountId: account.accountId,
           messageId,
           senderId: maskPII(senderId),
-          from: ctxPayload.From,
-          sessionKey,
+          from: maskPII(ctxPayload.From),
+          to: maskPII(ctxPayload.To),
+          sessionKey: maskPII(sessionKey),
           len: bodyText.length,
-          preview: previewLine,
+          preview: maskPII(previewLine),
         }),
       );
 
@@ -596,7 +597,7 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
         core.log?.(
           formatZulipLog("zulip monitor cleaning up queue", {
             accountId: account.accountId,
-            queueId: queue.queueId,
+            queueId: maskPII(queue.queueId),
           }),
         );
         await deleteZulipQueue(client, queue.queueId);

--- a/src/zulip/polling.ts
+++ b/src/zulip/polling.ts
@@ -1,7 +1,7 @@
 import type { PluginRuntime } from "openclaw/plugin-sdk";
 import type { ZulipMessage } from "./client.js";
 import { getZulipEventsWithRetry } from "./client.js";
-import { formatZulipLog, delay } from "./monitor-helpers.js";
+import { formatZulipLog, delay, maskPII } from "./monitor-helpers.js";
 import { ZulipQueueManager } from "./queue-manager.js";
 import type { MonitorZulipOpts } from "./monitor.js";
 
@@ -68,7 +68,7 @@ export async function pollOnce(params: {
       core.log?.(
         formatZulipLog("zulip events received", {
           accountId,
-          queueId: queue.queueId,
+          queueId: maskPII(queue.queueId),
           count: events.length,
         }),
       );

--- a/src/zulip/reply-handler.ts
+++ b/src/zulip/reply-handler.ts
@@ -74,7 +74,7 @@ export async function dispatchZulipReply(params: {
       logTypingFailure({
         log: logVerboseMessage,
         channel: "zulip",
-        target: isDM ? senderId : `stream:${streamId}:${topic}`,
+        target: maskPII(isDM ? senderId : `stream:${streamId}:${topic}`),
         error: err,
       });
     },
@@ -82,7 +82,7 @@ export async function dispatchZulipReply(params: {
       logTypingFailure({
         log: logVerboseMessage,
         channel: "zulip",
-        target: isDM ? senderId : `stream:${streamId}:${topic}`,
+        target: maskPII(isDM ? senderId : `stream:${streamId}:${topic}`),
         error: err,
       });
     },

--- a/src/zulip/send.ts
+++ b/src/zulip/send.ts
@@ -201,7 +201,7 @@ export async function sendMessageZulip(
       core.log?.(
         formatZulipLog("zulip outbound security warning: rejected non-http mediaUrl", {
           accountId: account.accountId,
-          mediaUrl,
+          mediaUrl: maskPII(mediaUrl),
         }),
       );
       mediaUrl = undefined;

--- a/test/monitor-helpers.test.ts
+++ b/test/monitor-helpers.test.ts
@@ -1,6 +1,44 @@
 import assert from "node:assert";
 import { test, describe } from "node:test";
-import { formatInboundFromLabel } from "../src/zulip/monitor-helpers.ts";
+import { formatInboundFromLabel, maskPII } from "../src/zulip/monitor-helpers.ts";
+
+describe("maskPII", () => {
+  test("returns empty string for null, undefined, or empty", () => {
+    assert.strictEqual(maskPII(null), "");
+    assert.strictEqual(maskPII(undefined), "");
+    assert.strictEqual(maskPII(""), "");
+    assert.strictEqual(maskPII("   "), "");
+  });
+
+  test("masks emails correctly", () => {
+    assert.strictEqual(maskPII("alice@example.com"), "a***@example.com");
+    assert.strictEqual(maskPII("a@b.com"), "***@b.com");
+  });
+
+  test("masks numeric IDs correctly", () => {
+    assert.strictEqual(maskPII("1"), "**");
+    assert.strictEqual(maskPII("12"), "**");
+    assert.strictEqual(maskPII("123"), "1***3");
+    assert.strictEqual(maskPII("12345"), "1***5");
+    assert.strictEqual(maskPII("123456"), "12***56");
+  });
+
+  test("masks user: prefixed strings", () => {
+    assert.strictEqual(maskPII("user:alice@example.com"), "user:a***@example.com");
+    assert.strictEqual(maskPII("user:12345"), "user:1***5");
+  });
+
+  test("masks stream: prefixed strings", () => {
+    assert.strictEqual(maskPII("stream:general"), "stream:ge***");
+    assert.strictEqual(maskPII("stream:my"), "stream:***");
+    assert.strictEqual(maskPII("stream:general:topic"), "stream:ge***:to***ic");
+  });
+
+  test("masks generic strings", () => {
+    assert.strictEqual(maskPII("ab"), "**");
+    assert.strictEqual(maskPII("abcde"), "ab***de");
+  });
+});
 
 describe("formatInboundFromLabel", () => {
   describe("when isGroup is true", () => {


### PR DESCRIPTION
This PR performs a comprehensive audit and tightening of Zulip runtime logging to prevent accidental sensitive-data exposure. 

Key improvements:
1.  **Enhanced Masking Utility:** The `maskPII` helper now supports more Zulip-specific prefixes (`dm:`, `zulip:`, `zulip:channel:`) and performs recursive masking for compound stream/topic strings.
2.  **Expanded Logging Privacy:** Applied masking to several critical fields that were previously logged in plain text, including `sessionKey`, `queueId`, `stream`, `topic`, and message previews.
3.  **Secure Snapshots:** The `ChannelAccountSnapshot` now masks the bot's email within the `probe` object to prevent leakage in status displays.
4.  **Robust Testing:** Added a full suite of test cases for the `maskPII` utility to ensure various PII formats are correctly handled.
5.  **Audit of Core Files:** Verified that `src/zulip/client.ts` and other core modules do not leak sensitive information through direct console logging.

Verified by running `npm run check` and adding targeted unit tests.

Fixes #119

---
*PR created automatically by Jules for task [891178802764038182](https://jules.google.com/task/891178802764038182) started by @niyazmft*