### PR TITLE
docs: update README for OpenClaw onboarding and remove stale references

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,185 +4,103 @@ The OpenClaw Zulip Bridge is a high-performance channel plugin for OpenClaw that
 
 ## Features
 
-- **Persistent Event Polling**: Automatically resumes from where it left off using locally-persisted queue metadata, surviving restarts without missing messages.
-- **Traffic Policies**: Granular control over who can interact with the bot in DMs (`pairing`, `allowlist`, `open`, `disabled`) and Streams (`allowlist`, `open`, `disabled`).
+- **Persistent Event Polling**: Automatically resumes from where it left off using locally-persisted queue metadata.
+- **Traffic Policies**: Granular control over who can interact with the bot in DMs and Streams.
 - **Multiple Accounts**: Support for multiple Zulip accounts and realms in a single instance.
-- **Mention Gating**: Intelligent stream handling with `oncall` (mention required), `onmessage` (responds to all), and `onchar` (trigger-character based) modes.
+- **Mention Gating**: Intelligent stream handling with `oncall`, `onmessage`, and `onchar` modes.
 - **Durable Deduplication**: Built-in persistent deduplication store to prevent duplicate message processing.
-- **Media Support**: Automatically downloads and processes Zulip uploads and inline images.
+- **Media Support**: Automatically processes Zulip uploads and inline images.
 - **Rich Feedback**: Optional reaction-based status indicators for request start, success, and errors.
 - **Standardized Observability**: Machine-parseable logs for easy monitoring and troubleshooting.
 
 ## Prerequisites
 
-Before installing the Zulip bridge, ensure you have:
 - **OpenClaw**: Version `>=2026.3.28`
-- **Node.js**: Latest LTS recommended (Node 22+ preferred)
+- **Node.js**: Latest LTS recommended (Node 22+)
+- **Zulip Bot**: A registered bot on your Zulip realm (Settings -> Your Bots -> Add a new bot).
 
-## Compatibility & CI
+## Installation
 
-This plugin is tested against the OpenClaw SDK to ensure stability and prevent regressions.
+The bridge can be installed via ClawHub or from source:
 
-### Supported Versions
-- **OpenClaw Runtime**: `>=2026.3.28`
-- **OpenClaw SDK**: Consistent with the `openclaw.compat` field in `package.json`.
-
-### CI Safeguards
-Every commit and pull request undergoes the following automated checks:
-- **Type Validation**: Full TypeScript type-check against SDK definitions.
-- **Unit & Integration Tests**: Functional verification of core logic (deduplication, policy, etc.).
-- **Package Integrity**: Verification of metadata consistency and existence of required build artifacts.
-- **Import Smoke Test**: Confirms the compiled `dist/` entry points can be imported without errors in a clean environment.
-- **Zulip Bot**: A registered bot on your Zulip realm.
-  1. Go to **Settings → Your Bots → Add a new bot**.
-  2. Choose **Generic bot** type.
-  3. Note your **Bot Email**, **API Key**, and **Zulip URL**.
-
-## Quickstart: Enable Zulip on a New Device
-
-Follow these steps to get Zulip running on a fresh OpenClaw setup.
-
-### 1. Clone and Install
-The extension must be installed inside your OpenClaw extensions directory. Navigate there first (creating it if necessary), then clone and install:
-
+### From ClawHub (Recommended)
 ```bash
-mkdir -p ~/.openclaw/extensions/
-cd ~/.openclaw/extensions/
-git clone https://github.com/niyazmft/openclaw-zulip-bridge.git
-cd openclaw-zulip-bridge
-npm install
-openclaw plugins install ./ --link
-openclaw plugins enable zulip
+openclaw plugins install clawhub:@openclaw/zulip
 ```
 
+### From Source
+```bash
+git clone https://github.com/niyazmft/openclaw-zulip-bridge.git ~/.openclaw/extensions/zulip
+cd ~/.openclaw/extensions/zulip
+npm install
+openclaw plugins install ./ --link
+```
 
+## Setup: Use OpenClaw Onboarding (Preferred)
 
-> **Note on Linked Plugins**: The `--link` flag creates a symbolic link from the OpenClaw extensions directory (typically `~/.openclaw/extensions/zulip`) back to your local repository checkout. This means the local repo **is** the source of truth for the installed plugin; any local code changes are reflected immediately after an OpenClaw restart without re-installing.
+Once installed, the preferred way to configure the Zulip bridge is using the OpenClaw onboarding wizard. This interactive setup handles credential validation and stream discovery.
 
-### 2. Configure OpenClaw
-It is highly recommended to use **environment variables** for your Zulip credentials to avoid storing secrets in plaintext in your configuration file.
+Run the setup command:
+```bash
+openclaw plugins setup zulip
+```
 
-#### Recommended: Using Environment Variables
-Set the following variables in your shell or `.env` file:
+### Onboarding Features
+- **Environment Variable Detection**: Automatically detects `ZULIP_API_KEY`, `ZULIP_EMAIL`, and `ZULIP_URL` if they are already set in your environment.
+- **Credential Validation**: Probes the Zulip API to verify your bot's credentials before saving.
+- **Stream Discovery**: Fetches the list of streams your bot is subscribed to and lets you choose which ones to monitor.
+- **DM Policy Configuration**: Easily set your preferred DM policy (pairing, open, allowlist, or disabled).
+
+## Manual Configuration (Fallback)
+
+While onboarding is recommended, you can also manually configure the bridge in your `openclaw.json`.
+
+### Recommended: Use Environment Variables
+To keep secrets out of your configuration file, set these in your environment:
 - `ZULIP_API_KEY`: Your bot's API key.
 - `ZULIP_EMAIL`: Your bot's email address.
 - `ZULIP_URL`: The base URL of your Zulip server.
 
-Then, your `~/.openclaw/openclaw.json` can remain simple:
+### Example `openclaw.json` entry:
 ```json
 {
   "channels": {
     "zulip": {
       "enabled": true,
-      "dmPolicy": "allowlist",
-      "allowFrom": [
-        "user@example.com"
-      ]
-    }
-  },
-  "plugins": {
-    "allow": ["zulip"],
-    "entries": {
-      "zulip": {
-        "enabled": true
-      }
-    },
-    "load": {
-      "paths": [
-        "~/.openclaw/extensions/zulip"
-      ]
+      "dmPolicy": "pairing",
+      "streams": ["*"]
     }
   }
 }
 ```
 
-### 3. Restart and Verify
-Restart OpenClaw to apply the changes.
+## Verification & First-Time Test
 
-**Verification Steps:**
-- **Check Logs**: Confirm success by looking for the initialization marker:
-  - `zulip queue registered [accountId=default queueId=... lastEventId=...]`
-  - (Or `zulip queue loaded [...]` if resuming from a previous session)
-- **Test DM**: Send a Direct Message to the bot. If `dmPolicy` is `pairing` (default), it should respond with a pairing code.
-- **Test Stream**: Mention the bot in the configured stream (e.g., `@bot-name hello`). The bot should receive the message and respond.
+After completing the setup, verify the bridge is working correctly:
 
-Success is confirmed when the bot is both **registered** in logs and **responding** to messages.
-
-## ClawHub Resources
-
-The bridge is published and maintained on [ClawHub](https://clawhub.ai):
-
-- **Plugin**: [OpenClaw Zulip Bridge](https://clawhub.ai/plugins/%40openclaw%2Fzulip) (`@openclaw/zulip`) — The core channel engine.
-- **Skill**: [Zulip Bridge](https://clawhub.ai/niyazmft/zulip-bridge) (`zulip-bridge`) — The AI agent instructions.
-
-To install via ClawHub:
-```bash
-openclaw plugins install clawhub:@openclaw/zulip
-```
-
-## Configuration Fields
-
-The setup is designed to work within `~/.openclaw/openclaw.json`. Here are the core fields you can configure:
-
-- **`enabled`**: (boolean) Set to `true` to enable the Zulip channel.
-- **`site`**: (string) The base URL of your Zulip server. These are interchangeable aliases.
-- **`email`**: (string) The email address of your Zulip bot.
-- **`apiKey`**: (string) The API key for your Zulip bot.
-- **`streams`**: (string[]) List of streams to monitor. Use `["*"]` for all.
-- **`dmPolicy`**: (string) Controls who can DM the bot. Options: `pairing`, `allowlist`, `open`, `disabled`.
-- **`groupPolicy`**: (string) Controls stream access. Options: `allowlist`, `open`, `disabled`.
-- **`allowFrom`**: (string[]) Authorized Zulip emails or user IDs (for DMs and commands).
-- **`chatmode`**: (enum) `oncall` (default), `onmessage`, or `onchar`.
-- **`streaming`**: (boolean) Core OpenClaw field to enable/disable response streaming.
-
-For a full list of over 20+ configuration options (reactions, media limits, etc.), see [docs/config.md](docs/config.md).
+1. **Check Logs**: Look for the registration success marker:
+   `zulip queue registered [accountId=default queueId=... lastEventId=...]`
+2. **Test Direct Message**: Send a private message to the bot. If using the default `pairing` policy, it should respond with a pairing code.
+3. **Test Stream Mention**: Mention the bot in a monitored stream (e.g., `@bot-name hello`). It should receive the message and respond.
 
 ## Troubleshooting
 
-- **Plugin Not Recognized**: Run `openclaw plugins list` to verify `zulip` is installed and enabled.
-  - Check the symlink: `ls -l ~/.openclaw/extensions/zulip` should point to your repo checkout.
-- **Queue Registration Fails**: Verify `ZULIP_URL` is reachable, and that `ZULIP_API_KEY` and `ZULIP_EMAIL` match exactly.
-- **Bot Not Responding in Streams**: Ensure the bot is a member of the stream and that the stream name is in the `streams` array.
-- **Logs show `mention required`**: By default, the bot only responds to @mentions in streams. Mention the bot or change `chatmode` to `onmessage`.
-
-## Advanced Configuration
-
-The bridge supports complex setups, including multiple accounts and custom traffic policies.
-
-- **Multiple Accounts**: See [docs/config.md](docs/config.md) for how to define additional accounts.
-- **Traffic Policies**: Detailed info on `dmPolicy` and `groupPolicy` is available in [docs/config.md](docs/config.md).
-- **Observability**: For machine-parseable log schemas and monitoring tips, see [docs/observability.md](docs/observability.md).
-- **Smoke Testing**: Step-by-step verification guide in [docs/smoke-test.md](docs/smoke-test.md).
+- **Queue Registration Fails**: Verify `ZULIP_URL` is reachable and credentials are correct. Use `openclaw plugins setup zulip` to re-verify.
+- **No Response in Streams**: Ensure the bot is a member of the stream and that the stream is listed in your `streams` config (or use `["*"]`).
+- **Logs show "mention required"**: By default, the bot only responds to @mentions in streams. Check your `chatmode` setting.
 
 ## Development
 
-### Prerequisites
-
-- Node.js (Latest LTS recommended)
-- `npm`
-
 ### Local Setup
-
-1. Install dependencies for plugin development:
-   ```bash
-   npm install
-   ```
-
-2. Run tests and type checks:
-   ```bash
-   npm run check
-   ```
-
-This `npm install` step is for **contributing to or testing the plugin codebase**; it is not the command for installing the plugin into your OpenClaw runtime.
-
-> **Note on `devDependencies`**: This project requires `typescript` and other dev tools for its build and validation steps. A `.npmrc` file is included to ensure these are installed even if `NODE_ENV=production` is set in your environment.
+1. `npm install`
+2. `npm run check` (Runs type-checks, build, and tests)
 
 ### Project Structure
-
-- `src/` — Plugin source code
-  - `zulip/` — Zulip-specific client, monitoring, and policy logic
-- `test/` — Local regression tests
-- `docs/` — Supporting documentation
+- `src/` — Plugin source code.
+  - `zulip/` — Zulip client and monitoring logic.
+- `test/` — Unit and integration tests.
+- `types/` — SDK type definitions and shims.
+- `openclaw.plugin.json` — Plugin manifest.
 
 ## License
 


### PR DESCRIPTION
This PR modernizes the Zulip extension README to align with the current OpenClaw onboarding experience. It replaces manual configuration instructions with the onboarding wizard, removes broken documentation links, and adds a verification checklist.

Fixes #133

---
*PR created automatically by Jules for task [2441986969729774296](https://jules.google.com/task/2441986969729774296) started by @niyazmft*