### PR TITLE
chore(release): v2026.4.10

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: zulip-bridge
-version: 2026.4.9
+version: 2026.4.10
 description: 💬 High-performance Zulip bridge skill. Enables messaging, stream monitoring, and administrative actions on Zulip servers.
 user-invocable: true
 metadata: {

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "zulip",
   "name": "Zulip",
   "description": "OpenClaw Zulip channel plugin",
-  "version": "2026.4.9",
+  "version": "2026.4.10",
   "kind": "channel",
   "channels": ["zulip"],
   "providerAuthEnvVars": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@openclaw/zulip",
-  "version": "2026.4.9",
+  "version": "2026.4.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openclaw/zulip",
-      "version": "2026.4.9",
+      "version": "2026.4.10",
       "devDependencies": {
         "@types/node": "^24.5.2",
         "typescript": "^5.9.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/zulip",
-  "version": "2026.4.9",
+  "version": "2026.4.10",
   "description": "OpenClaw Zulip channel plugin",
   "type": "module",
   "openclaw": {


### PR DESCRIPTION
Bumping version for a clean ClawHub publish without development scripts.