### PR TITLE
feat(sdk): migrate to defineChannelPluginEntry and wire onboarding

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,17 +1,37 @@
-import { emptyPluginConfigSchema, definePluginEntry } from "openclaw/plugin-sdk/core";
+import { defineChannelPluginEntry } from "openclaw/plugin-sdk/core";
 import { zulipPlugin } from "./src/channel.js";
 import { setZulipRuntime } from "./src/runtime.js";
+import { zulipOnboardingAdapter } from "./src/onboarding.js";
 
 export { zulipPlugin } from "./src/channel.js";
 export { setZulipRuntime } from "./src/runtime.js";
 
-export default definePluginEntry({
+export default defineChannelPluginEntry({
   id: "zulip",
   name: "Zulip",
   description: "Zulip channel plugin",
-  configSchema: emptyPluginConfigSchema(),
-  register(api) {
+  plugin: zulipPlugin,
+  registerCliMetadata(api) {
+    api.registerCli(
+      ({ program }) => {
+        program.command("zulip").description("Zulip channel management");
+      },
+      {
+        descriptors: [
+          {
+            name: "zulip",
+            description: "Zulip channel management",
+            hasSubcommands: false,
+          },
+        ],
+      },
+    );
+  },
+  registerFull(api) {
     setZulipRuntime(api.runtime);
     api.registerChannel({ plugin: zulipPlugin });
+    if (api.registerOnboarding) {
+      api.registerOnboarding(zulipOnboardingAdapter);
+    }
   },
 });

--- a/package.json
+++ b/package.json
@@ -27,7 +27,13 @@
       "docsPath": "/channels/zulip",
       "docsLabel": "zulip",
       "blurb": "Zulip streams/topics with reaction-based reply indicators (plugin, installed separately).",
-      "order": 70
+      "order": 70,
+      "exposure": {
+        "configured": true,
+        "setup": true,
+        "docs": true
+      },
+      "quickstartAllowFrom": true
     },
     "install": {
       "localPath": ".",

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -422,9 +422,10 @@ export const zulipMessageActions: ChannelMessageActionAdapter = {
       "pin",
       "unpin",
     ]);
-    // TODO: These actions require core SDK changes to MESSAGE_ACTION_TARGET_MODE.
-    // Re-enable once the SDK supports plugin-registered action target modes.
-    // See: https://github.com/openclaw/openclaw/issues/TBD
+    // TODO: These actions are implemented below but not yet exposed because core's
+    // MESSAGE_ACTION_TARGET_MODE does not yet support plugin-registered action target modes.
+    // Track: https://github.com/niyazmft/openclaw-zulip-bridge/issues
+    // Re-enable once the SDK exposes a plugin-registered action target mode API.
     // actions.add("channel-subscribe" as ChannelMessageActionName);
     // actions.add("invite" as ChannelMessageActionName);
     // actions.add("resolve-topic" as ChannelMessageActionName);

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -108,6 +108,7 @@ export const zulipPlugin = createChatChannelPlugin<ResolvedZulipAccount>({
         apiKeySource: account.apiKeySource,
         emailSource: account.emailSource,
         baseUrl: account.baseUrl,
+        enableAdminActions: account.enableAdminActions ?? false,
       }),
       resolveAllowFrom: ({ cfg, accountId }) =>
         (resolveZulipAccount({ cfg, accountId }).config.allowFrom ?? []).map((entry) =>

--- a/src/setup-surface.ts
+++ b/src/setup-surface.ts
@@ -33,6 +33,73 @@ function resolveSetupAccountId(cfg: OpenClawConfig, accountId: string): string {
   return accountId || resolveDefaultZulipAccountId(cfg) || DEFAULT_ACCOUNT_ID;
 }
 
+/**
+ * Credential text inputs (API key, email, site URL) shared by the setup wizard.
+ * Kept as a named constant so the allowFrom follow-up input can be appended
+ * after the dmPolicy select without duplicating the credential definitions.
+ */
+const ZULIP_CREDENTIAL_TEXT_INPUTS = [
+  {
+    inputKey: "apiKey",
+    message: "Enter Zulip API key",
+    confirmCurrentValue: false,
+    currentValue: ({ cfg, accountId }: { cfg: OpenClawConfig; accountId: string }) =>
+      resolveZulipAccount({ cfg, accountId: resolveSetupAccountId(cfg, accountId) }).apiKey ??
+      (resolveSetupAccountId(cfg, accountId) === DEFAULT_ACCOUNT_ID
+        ? process.env.ZULIP_API_KEY?.trim()
+        : undefined),
+    initialValue: ({ cfg, accountId }: { cfg: OpenClawConfig; accountId: string }) =>
+      resolveZulipAccount({ cfg, accountId: resolveSetupAccountId(cfg, accountId) }).apiKey ??
+      (resolveSetupAccountId(cfg, accountId) === DEFAULT_ACCOUNT_ID
+        ? process.env.ZULIP_API_KEY?.trim()
+        : undefined),
+    validate: ({ value }: { value: string }) => (value?.trim() ? undefined : "Zulip API key is required."),
+    normalizeValue: ({ value }: { value: string }) => value.trim(),
+  },
+  {
+    inputKey: "email",
+    message: "Enter Zulip bot email",
+    confirmCurrentValue: false,
+    currentValue: ({ cfg, accountId }: { cfg: OpenClawConfig; accountId: string }) =>
+      resolveZulipAccount({ cfg, accountId: resolveSetupAccountId(cfg, accountId) }).email ??
+      (resolveSetupAccountId(cfg, accountId) === DEFAULT_ACCOUNT_ID
+        ? process.env.ZULIP_EMAIL?.trim()
+        : undefined),
+    initialValue: ({ cfg, accountId }: { cfg: OpenClawConfig; accountId: string }) =>
+      resolveZulipAccount({ cfg, accountId: resolveSetupAccountId(cfg, accountId) }).email ??
+      (resolveSetupAccountId(cfg, accountId) === DEFAULT_ACCOUNT_ID
+        ? process.env.ZULIP_EMAIL?.trim()
+        : undefined),
+    validate: ({ value }: { value: string }) => (value?.trim() ? undefined : "Zulip bot email is required."),
+    normalizeValue: ({ value }: { value: string }) => value.trim(),
+  },
+  {
+    inputKey: "httpUrl",
+    message: "Enter Zulip site URL",
+    confirmCurrentValue: false,
+    currentValue: ({ cfg, accountId }: { cfg: OpenClawConfig; accountId: string }) =>
+      resolveZulipAccount({ cfg, accountId: resolveSetupAccountId(cfg, accountId) }).baseUrl ??
+      (resolveSetupAccountId(cfg, accountId) === DEFAULT_ACCOUNT_ID
+        ? process.env.ZULIP_URL?.trim()
+        : undefined),
+    initialValue: ({ cfg, accountId }: { cfg: OpenClawConfig; accountId: string }) =>
+      resolveZulipAccount({ cfg, accountId: resolveSetupAccountId(cfg, accountId) }).baseUrl ??
+      (resolveSetupAccountId(cfg, accountId) === DEFAULT_ACCOUNT_ID
+        ? process.env.ZULIP_URL?.trim()
+        : undefined),
+    validate: ({ value }: { value: string }) => {
+      const trimmed = value?.trim();
+      if (!trimmed) {
+        return "Zulip site URL is required.";
+      }
+      return normalizeZulipBaseUrl(trimmed)
+        ? undefined
+        : "Enter a valid URL including protocol, for example: https://chat.example.com";
+    },
+    normalizeValue: ({ value }: { value: string }) => normalizeZulipBaseUrl(value) ?? value.trim(),
+  },
+] as const;
+
 export const zulipSetupWizard: ChannelSetupWizard = {
   channel,
   status: createStandardChannelSetupStatus({
@@ -82,64 +149,41 @@ export const zulipSetupWizard: ChannelSetupWizard = {
     apply: ({ cfg }) => cfg,
   },
   textInputs: [
+    ...ZULIP_CREDENTIAL_TEXT_INPUTS,
     {
-      inputKey: "apiKey",
-      message: "Enter Zulip API key",
-      confirmCurrentValue: false,
-      currentValue: ({ cfg, accountId }) =>
-        resolveZulipAccount({ cfg, accountId: resolveSetupAccountId(cfg, accountId) }).apiKey ??
-        (resolveSetupAccountId(cfg, accountId) === DEFAULT_ACCOUNT_ID
-          ? process.env.ZULIP_API_KEY?.trim()
-          : undefined),
-      initialValue: ({ cfg, accountId }) =>
-        resolveZulipAccount({ cfg, accountId: resolveSetupAccountId(cfg, accountId) }).apiKey ??
-        (resolveSetupAccountId(cfg, accountId) === DEFAULT_ACCOUNT_ID
-          ? process.env.ZULIP_API_KEY?.trim()
-          : undefined),
-      validate: ({ value }) => (value?.trim() ? undefined : "Zulip API key is required."),
-      normalizeValue: ({ value }) => value.trim(),
-    },
-    {
-      inputKey: "email",
-      message: "Enter Zulip bot email",
-      confirmCurrentValue: false,
-      currentValue: ({ cfg, accountId }) =>
-        resolveZulipAccount({ cfg, accountId: resolveSetupAccountId(cfg, accountId) }).email ??
-        (resolveSetupAccountId(cfg, accountId) === DEFAULT_ACCOUNT_ID
-          ? process.env.ZULIP_EMAIL?.trim()
-          : undefined),
-      initialValue: ({ cfg, accountId }) =>
-        resolveZulipAccount({ cfg, accountId: resolveSetupAccountId(cfg, accountId) }).email ??
-        (resolveSetupAccountId(cfg, accountId) === DEFAULT_ACCOUNT_ID
-          ? process.env.ZULIP_EMAIL?.trim()
-          : undefined),
-      validate: ({ value }) => (value?.trim() ? undefined : "Zulip bot email is required."),
-      normalizeValue: ({ value }) => value.trim(),
-    },
-    {
-      inputKey: "httpUrl",
-      message: "Enter Zulip site URL",
-      confirmCurrentValue: false,
-      currentValue: ({ cfg, accountId }) =>
-        resolveZulipAccount({ cfg, accountId: resolveSetupAccountId(cfg, accountId) }).baseUrl ??
-        (resolveSetupAccountId(cfg, accountId) === DEFAULT_ACCOUNT_ID
-          ? process.env.ZULIP_URL?.trim()
-          : undefined),
-      initialValue: ({ cfg, accountId }) =>
-        resolveZulipAccount({ cfg, accountId: resolveSetupAccountId(cfg, accountId) }).baseUrl ??
-        (resolveSetupAccountId(cfg, accountId) === DEFAULT_ACCOUNT_ID
-          ? process.env.ZULIP_URL?.trim()
-          : undefined),
-      validate: ({ value }) => {
-        const trimmed = value?.trim();
-        if (!trimmed) {
-          return "Zulip site URL is required.";
-        }
-        return normalizeZulipBaseUrl(trimmed)
-          ? undefined
-          : "Enter a valid URL including protocol, for example: https://chat.example.com";
+      // Conditionally shown when dmPolicy is set to "allowlist".
+      inputKey: "allowFrom",
+      message: "Enter allowed sender emails (comma-separated)",
+      hint: "Only these Zulip email addresses can DM the bot. Example: alice@example.com, bob@example.com",
+      placeholder: "e.g. alice@example.com, bob@example.com",
+      shouldPrompt: ({ cfg, accountId }: { cfg: OpenClawConfig; accountId: string }) => {
+        const resolved = resolveZulipAccount({
+          cfg,
+          accountId: resolveSetupAccountId(cfg, accountId),
+        });
+        return (resolved.config.dmPolicy ?? "pairing") === "allowlist";
       },
-      normalizeValue: ({ value }) => normalizeZulipBaseUrl(value) ?? value.trim(),
+      currentValue: ({ cfg, accountId }: { cfg: OpenClawConfig; accountId: string }) => {
+        const resolved = resolveZulipAccount({
+          cfg,
+          accountId: resolveSetupAccountId(cfg, accountId),
+        });
+        return (resolved.config.allowFrom ?? []).join(", ");
+      },
+      initialValue: ({ cfg, accountId }: { cfg: OpenClawConfig; accountId: string }) => {
+        const resolved = resolveZulipAccount({
+          cfg,
+          accountId: resolveSetupAccountId(cfg, accountId),
+        });
+        return (resolved.config.allowFrom ?? []).join(", ");
+      },
+      validate: ({ value }: { value: string }) => {
+        if (!value?.trim()) {
+          return "At least one email is required when dmPolicy is allowlist.";
+        }
+        return undefined;
+      },
+      normalizeValue: ({ value }: { value: string }) => value.trim(),
     },
   ],
   selects: [


### PR DESCRIPTION
- Replace definePluginEntry with defineChannelPluginEntry in index.ts per OpenClaw SDK channel plugin standard; enables channel lifecycle hooks, openclaw onboard, openclaw config, and CLI subcommand registration
- Add registerCliMetadata for 'openclaw zulip' CLI namespace
- Move runtime wiring to registerFull
- Wire previously-orphaned zulipOnboardingAdapter so openclaw onboard exposes Zulip in the channel picker (Gap 6)
- Add exposure: { configured, setup, docs } + quickstartAllowFrom to package.json openclaw.channel (Gap 5)
- Add conditional allowFrom textInput to setup wizard: shown only when dmPolicy=allowlist, closing the inline-config gap in openclaw config
- Expose enableAdminActions in describeAccount for openclaw channels status
- Update blocked-action TODO comments with actionable tracker link (Gap 7)

All 71 tests pass. npm run check exit code 0.