### PR TITLE
fix(index): use definePluginEntry for openclaw registration

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,4 +1,4 @@
-import { defineChannelPluginEntry } from "openclaw/plugin-sdk/core";
+import { definePluginEntry } from "openclaw/plugin-sdk/core";
 import { zulipPlugin } from "./src/channel.js";
 import { setZulipRuntime } from "./src/runtime.js";
 import { zulipOnboardingAdapter } from "./src/onboarding.js";
@@ -6,11 +6,10 @@ import { zulipOnboardingAdapter } from "./src/onboarding.js";
 export { zulipPlugin } from "./src/channel.js";
 export { setZulipRuntime } from "./src/runtime.js";
 
-export default defineChannelPluginEntry({
+export default definePluginEntry({
   id: "zulip",
   name: "Zulip",
   description: "Zulip channel plugin",
-  plugin: zulipPlugin,
   registerCliMetadata(api) {
     api.registerCli(
       ({ program }) => {

--- a/test/openclaw-plugin-sdk-shim.js
+++ b/test/openclaw-plugin-sdk-shim.js
@@ -25,7 +25,6 @@ const noOp = () => undefined;
 export const emptyPluginConfigSchema = () => ({});
 export const definePluginEntry = (entry) => entry;
 export const defineSetupPluginEntry = (entry) => entry;
-export const defineChannelPluginEntry = (entry) => entry;
 export const createChatChannelPlugin = (entry) => entry;
 export const defineChannelTargetParser = (parser) => parser;
 export const defineOnboardingProvider = (provider) => provider;


### PR DESCRIPTION
The plugin was registering twice because `defineChannelPluginEntry` implicitly registers the channel, and `registerFull` was also manually registering the channel. Changed `defineChannelPluginEntry` to `definePluginEntry` and removed the `plugin` property from the configuration passed to it.

---
*PR created automatically by Jules for task [5303783456873055423](https://jules.google.com/task/5303783456873055423) started by @niyazmft*