### PR TITLE
⚡ Bolt: Batch disk I/O updates for event ID in polling loop

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-06-25 - Batching Disk I/O operations in Event Polling Loop
+**Learning:** The event polling loop in Zulip queue manager repeatedly flushed metadata to disk (O(N) operations) for every processed event, causing excessive disk I/O when processing large batches of events.
+**Action:** When iterating over a batch of items that each require an update to a persisted state or cursor (like an `eventId`), keep track of the maximum value within the loop block, and perform a single write/update (O(1)) at the end of the batch instead of continuously updating it for each item.

--- a/src/zulip/polling.ts
+++ b/src/zulip/polling.ts
@@ -85,13 +85,26 @@ export async function pollOnce(params: {
     resetPollBackoff();
     pollBackoffMs = 0;
 
-    for (const event of events) {
-      if (event.type === "message" && event.message) {
-        await processMessage(event.message);
+    let maxEventId = -1;
+
+    try {
+      for (const event of events) {
+        if (event.type === "message" && event.message) {
+          await processMessage(event.message);
+        }
+        const nextEventId = Number((event as { id?: unknown })?.id);
+        if (!Number.isNaN(nextEventId) && nextEventId > maxEventId) {
+          maxEventId = nextEventId;
+        }
       }
-      const nextEventId = Number((event as { id?: unknown })?.id);
-      if (!Number.isNaN(nextEventId) && nextEventId > 0) {
-        await queueManager.updateLastEventId(nextEventId);
+    } finally {
+      if (maxEventId > 0) {
+        // ⚡ Bolt Optimization: Batch disk I/O updates for event ID
+        // Previously, we updated the queue manager (which writes to disk) for every event.
+        // By keeping track of the maxEventId and updating once per batch, we turn
+        // O(N) disk writes into O(1) writes, drastically reducing I/O operations.
+        // It's in a finally block to make sure progress is not lost upon errors.
+        await queueManager.updateLastEventId(maxEventId);
       }
     }
   } catch (err) {


### PR DESCRIPTION
💡 **What**: Refactored the `pollOnce` function in `src/zulip/polling.ts` to batch calls to `queueManager.updateLastEventId(nextEventId)`. We now track the highest event ID in a variable (`maxEventId`) and update the file on disk only once at the end of the batch inside a `finally` block.

🎯 **Why**: Previously, the function updated the `lastEventId` on disk for every single event processed. This resulted in O(N) disk I/O operations per batch, which is a significant bottleneck when processing large volumes of queued messages.

📊 **Impact**: Reduces disk I/O operations from O(N) to O(1) for event processing batches. This drastically reduces file system overhead and improves overall throughput for the polling loop.

🔬 **Measurement**: To verify, process a batch of N messages and observe the file modification times/system calls. Previously there would be N file writes; now there should be 1. Ensure `npm test` continues to pass, as this change fully preserves failure and retry semantics via the `finally` block.

---
*PR created automatically by Jules for task [14360994228798984406](https://jules.google.com/task/14360994228798984406) started by @niyazmft*