### PR TITLE
Security: API Injection hardening via URL encoding in Zulip client

### DIFF
--- a/src/zulip/client.ts
+++ b/src/zulip/client.ts
@@ -254,7 +254,7 @@ export async function fetchZulipMe(client: ZulipClient): Promise<ZulipUser> {
 export async function fetchZulipUser(client: ZulipClient, userId: string): Promise<ZulipUser> {
   const payload = await client.request<
     ZulipApiResponse & { user?: { user_id: number; email?: string; full_name?: string } }
-  >(`/users/${userId}`);
+  >(`/users/${encodeURIComponent(userId)}`);
   assertSuccess(payload, "Zulip /users/{id} failed");
   const user = payload.user;
   return {
@@ -281,7 +281,7 @@ export async function fetchZulipStream(
 ): Promise<ZulipStream> {
   const payload = await client.request<
     ZulipApiResponse & { stream?: { stream_id: number; name?: string; description?: string } }
-  >(`/streams/${streamId}`);
+  >(`/streams/${encodeURIComponent(streamId)}`);
   assertSuccess(payload, "Zulip /streams/{id} failed");
   const stream = payload.stream;
   return {
@@ -389,9 +389,12 @@ export async function deleteZulipQueue(client: ZulipClient, queueId: string): Pr
     return;
   }
   try {
-    const payload = await client.request<ZulipApiResponse>(`/events?queue_id=${queueId}`, {
-      method: "DELETE",
-    });
+    const payload = await client.request<ZulipApiResponse>(
+      `/events?queue_id=${encodeURIComponent(queueId)}`,
+      {
+        method: "DELETE",
+      },
+    );
     assertSuccess(payload, "Zulip delete event queue failed");
   } catch {
     // ignore cleanup errors
@@ -673,17 +676,23 @@ export async function updateZulipStream(
   if (params.isDefaultStream !== undefined) {
     body.set("is_default_stream", String(params.isDefaultStream));
   }
-  const payload = await client.request<ZulipApiResponse>(`/streams/${params.streamId}` as const, {
-    method: "PATCH",
-    body: body.toString(),
-  });
+  const payload = await client.request<ZulipApiResponse>(
+    `/streams/${encodeURIComponent(params.streamId)}` as const,
+    {
+      method: "PATCH",
+      body: body.toString(),
+    },
+  );
   assertSuccess(payload, "Zulip stream update failed");
 }
 
 export async function deleteZulipStream(client: ZulipClient, streamId: string): Promise<void> {
-  const payload = await client.request<ZulipApiResponse>(`/streams/${streamId}` as const, {
-    method: "DELETE",
-  });
+  const payload = await client.request<ZulipApiResponse>(
+    `/streams/${encodeURIComponent(streamId)}` as const,
+    {
+      method: "DELETE",
+    },
+  );
   assertSuccess(payload, "Zulip stream delete failed");
 }
 
@@ -707,7 +716,7 @@ export async function addZulipReaction(
   }
   const payload = await zulipRequestWithRetry<ZulipApiResponse>(
     client,
-    `/messages/${params.messageId}/reactions`,
+    `/messages/${encodeURIComponent(params.messageId)}/reactions`,
     { method: "POST", body: body.toString() },
   );
   assertSuccess(payload, "Zulip add reaction failed");
@@ -735,7 +744,7 @@ export async function removeZulipReaction(
   const suffix = qs.toString();
   const payload = await zulipRequestWithRetry<ZulipApiResponse>(
     client,
-    `/messages/${params.messageId}/reactions${suffix ? `?${suffix}` : ""}`,
+    `/messages/${encodeURIComponent(params.messageId)}/reactions${suffix ? `?${suffix}` : ""}`,
     { method: "DELETE" },
   );
   assertSuccess(payload, "Zulip remove reaction failed");
@@ -751,10 +760,13 @@ export async function editZulipMessage(
   const body = new URLSearchParams({
     content: params.content,
   });
-  const payload = await client.request<ZulipApiResponse>(`/messages/${params.messageId}`, {
-    method: "PATCH",
-    body: body.toString(),
-  });
+  const payload = await client.request<ZulipApiResponse>(
+    `/messages/${encodeURIComponent(params.messageId)}`,
+    {
+      method: "PATCH",
+      body: body.toString(),
+    },
+  );
   assertSuccess(payload, "Zulip edit message failed");
 }
 
@@ -764,9 +776,12 @@ export async function deleteZulipMessage(
     messageId: string;
   },
 ): Promise<void> {
-  const payload = await client.request<ZulipApiResponse>(`/messages/${params.messageId}`, {
-    method: "DELETE",
-  });
+  const payload = await client.request<ZulipApiResponse>(
+    `/messages/${encodeURIComponent(params.messageId)}`,
+    {
+      method: "DELETE",
+    },
+  );
   assertSuccess(payload, "Zulip delete message failed");
 }
 
@@ -808,10 +823,13 @@ export async function updateZulipMessageTopic(
     topic: params.topic,
     propagate_mode: params.propagateMode ?? "change_all",
   });
-  const payload = await client.request<ZulipApiResponse>(`/messages/${params.messageId}`, {
-    method: "PATCH",
-    body: body.toString(),
-  });
+  const payload = await client.request<ZulipApiResponse>(
+    `/messages/${encodeURIComponent(params.messageId)}`,
+    {
+      method: "PATCH",
+      body: body.toString(),
+    },
+  );
   assertSuccess(payload, "Zulip update message topic failed");
 }
 
@@ -892,9 +910,12 @@ export async function deactivateZulipUser(client: ZulipClient, userId: string): 
   if (!trimmed) {
     throw new Error("userId is required to deactivate a Zulip user.");
   }
-  const payload = await client.request<ZulipApiResponse>(`/users/${trimmed}` as const, {
-    method: "DELETE",
-  });
+  const payload = await client.request<ZulipApiResponse>(
+    `/users/${encodeURIComponent(trimmed)}` as const,
+    {
+      method: "DELETE",
+    },
+  );
   assertSuccess(payload, "Zulip deactivate user failed");
 }
 
@@ -903,9 +924,12 @@ export async function reactivateZulipUser(client: ZulipClient, userId: string): 
   if (!trimmed) {
     throw new Error("userId is required to reactivate a Zulip user.");
   }
-  const payload = await client.request<ZulipApiResponse>(`/users/${trimmed}/reactivate` as const, {
-    method: "POST",
-  });
+  const payload = await client.request<ZulipApiResponse>(
+    `/users/${encodeURIComponent(trimmed)}/reactivate` as const,
+    {
+      method: "POST",
+    },
+  );
   assertSuccess(payload, "Zulip reactivate user failed");
 }
 

--- a/test/security-url-encoding.test.ts
+++ b/test/security-url-encoding.test.ts
@@ -1,0 +1,102 @@
+import { test, describe } from "node:test";
+import assert from "node:assert";
+import {
+  createZulipClient,
+  fetchZulipUser,
+  fetchZulipStream,
+  deleteZulipQueue,
+  deactivateZulipUser,
+  reactivateZulipUser,
+  addZulipReaction,
+  removeZulipReaction,
+  editZulipMessage,
+  deleteZulipMessage,
+  updateZulipMessageTopic,
+  fetchZulipUserPresence
+} from "../src/zulip/client.ts";
+
+describe("Zulip Client URL Encoding Security", () => {
+  let capturedUrl = "";
+
+  const mockClient = createZulipClient({
+    baseUrl: "https://zulip.example.com",
+    email: "bot@example.com",
+    apiKey: "secret",
+    fetchImpl: async (url) => {
+      capturedUrl = url.toString();
+      return {
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        headers: new Headers({ "content-type": "application/json" }),
+        json: async () => ({
+          result: "success",
+          user: { user_id: 123 },
+          stream: { stream_id: 456 },
+          presence: {}
+        }),
+      } as any;
+    }
+  });
+
+  test("fetchZulipUser should encode userId", async () => {
+    const userId = "user/../me";
+    await fetchZulipUser(mockClient, userId);
+    assert.ok(capturedUrl.includes("/users/user%2F..%2Fme"), `URL was not encoded: ${capturedUrl}`);
+  });
+
+  test("fetchZulipStream should encode streamId", async () => {
+    const streamId = "Engineering/Alerts";
+    await fetchZulipStream(mockClient, streamId);
+    assert.ok(capturedUrl.includes("/streams/Engineering%2FAlerts"), `URL was not encoded: ${capturedUrl}`);
+  });
+
+  test("deleteZulipQueue should encode queueId", async () => {
+    const queueId = "123&other=param";
+    await deleteZulipQueue(mockClient, queueId);
+    assert.ok(capturedUrl.includes("queue_id=123%26other%3Dparam"), `URL was not encoded: ${capturedUrl}`);
+  });
+
+  test("deactivateZulipUser should encode userId", async () => {
+    const userId = "bad/user";
+    await deactivateZulipUser(mockClient, userId);
+    assert.ok(capturedUrl.includes("/users/bad%2Fuser"), `URL was not encoded: ${capturedUrl}`);
+  });
+
+  test("reactivateZulipUser should encode userId", async () => {
+    const userId = "bad/user";
+    await reactivateZulipUser(mockClient, userId);
+    assert.ok(capturedUrl.includes("/users/bad%2Fuser/reactivate"), `URL was not encoded: ${capturedUrl}`);
+  });
+
+  test("addZulipReaction should encode messageId", async () => {
+    await addZulipReaction(mockClient, { messageId: "123/456", emojiName: "thumbs_up" });
+    assert.ok(capturedUrl.includes("/messages/123%2F456/reactions"), `URL was not encoded: ${capturedUrl}`);
+  });
+
+  test("removeZulipReaction should encode messageId", async () => {
+    await removeZulipReaction(mockClient, { messageId: "123/456", emojiName: "thumbs_up" });
+    assert.ok(capturedUrl.includes("/messages/123%2F456/reactions"), `URL was not encoded: ${capturedUrl}`);
+  });
+
+  test("editZulipMessage should encode messageId", async () => {
+    await editZulipMessage(mockClient, { messageId: "123/456", content: "new content" });
+    assert.ok(capturedUrl.includes("/messages/123%2F456"), `URL was not encoded: ${capturedUrl}`);
+  });
+
+  test("deleteZulipMessage should encode messageId", async () => {
+    await deleteZulipMessage(mockClient, { messageId: "123/456" });
+    assert.ok(capturedUrl.includes("/messages/123%2F456"), `URL was not encoded: ${capturedUrl}`);
+  });
+
+  test("updateZulipMessageTopic should encode messageId", async () => {
+    await updateZulipMessageTopic(mockClient, { messageId: "123/456", topic: "new topic" });
+    assert.ok(capturedUrl.includes("/messages/123%2F456"), `URL was not encoded: ${capturedUrl}`);
+  });
+
+  test("fetchZulipUserPresence should encode userIdOrEmail", async () => {
+    // This one is already encoded in the source, verifying it stays that way
+    await fetchZulipUserPresence(mockClient, "user@example.com");
+    assert.ok(capturedUrl.includes("/users/user%40example.com/presence"), `URL was not encoded: ${capturedUrl}`);
+  });
+});


### PR DESCRIPTION
Harden Zulip API client by encoding dynamic identifiers in request paths.

Fixes #150

---
*PR created automatically by Jules for task [14807379611980393000](https://jules.google.com/task/14807379611980393000) started by @niyazmft*