### PR TITLE
chore: update SKILL.md version to 2026.4.13

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: zulip-bridge
-version: 2026.4.12
+version: 2026.4.13
 description: 💬 High-performance Zulip bridge skill. Enables messaging, stream monitoring, and administrative actions on Zulip servers.
 user-invocable: true
 metadata: {


### PR DESCRIPTION
SKILL.md frontmatter still had version 2026.4.12 — bumped to match package.json and openclaw.plugin.json at 2026.4.13.