### PR TITLE
fix: mask apiKey in loadConfig log to prevent credential leakage

### DIFF
--- a/src/zulip/monitor.ts
+++ b/src/zulip/monitor.ts
@@ -85,7 +85,10 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
     const oncharPrefixes = resolveOncharPrefixes(account.oncharPrefixes);
     const oncharEnabled = account.chatmode === "onchar";
 
-    logger?.info?.("loadConfig result", { zulipSection: cfg?.channels?.zulip });
+    logger?.info?.("loadConfig result", {
+      zulipAccountIds: Object.keys(cfg?.channels?.zulip?.accounts || {}),
+      hasApiKey: Boolean(cfg?.channels?.zulip?.apiKey),
+    });
     const mediaMaxBytes =
       resolveChannelMediaMaxBytes({
         cfg: cfg,


### PR DESCRIPTION
## Summary
- Changed  log to only log safe metadata (account IDs and presence of apiKey) instead of entire config section
- Prevents apiKey credentials from appearing in plaintext logs

## Security
This fixes a pre-existing security issue where apiKeys were being logged in plaintext.