### PR TITLE
⚡ Bolt: Skip allowlist disk read if user is already configured

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,6 @@
 ## 2026-05-11 - Optimization: Hoist botUsernameMention computation outside message handler loop
 **Learning:** We observed that `botUsername.toLowerCase()` was being called repeatedly inside the `handleMessage` loop. Although a small operation, avoiding string allocation and processing on a hot path like checking every message string is a nice micro-optimization, especially for busy channels.
 **Action:** Lift static computations outside the event loop processing path to save memory and CPU on hot paths. E.g., caching `botUsernameMention = '@' + botUsername.toLowerCase()` directly below other config lookups.
+## 2026-05-13 - Optimization: Skip disk read if user is already allowed via config
+**Learning:** Found that `readAllowFromStore("zulip")` reads from disk every time `handleMessage` processes a message, which is a hot path. Since we already check `configAllowFrom` and `configGroupAllowFrom` before, if the user matches in the config allowlists, reading from disk (store) is entirely unnecessary and causes redundant file system access.
+**Action:** By checking `!senderAllowedForCommands || !groupAllowedForCommands` *before* loading `storeAllowFrom`, we can skip the disk read and the extra `Array.from(new Set(...))` operations for users already allowed in the configuration, improving message throughput on the hot path.

--- a/patch2.js
+++ b/patch2.js
@@ -1,0 +1,38 @@
+const fs = require('fs');
+let code = fs.readFileSync('src/zulip/monitor.ts', 'utf8');
+
+const search = `      // ⚡ Bolt Optimization: Skip disk read if user is already allowed via config
+      // We only need to check the store allowlist if they aren't authorized yet.
+      // This saves a filesystem access on the hot path for authorized users.
+      if (!senderAllowedForCommands || !groupAllowedForCommands) {
+        const storeAllowFrom = normalizeAllowList(
+          await core.channel.pairing.readAllowFromStore("zulip").catch(() => []),
+        );
+        effectiveAllowFrom = Array.from(new Set([...configAllowFrom, ...storeAllowFrom]));
+        effectiveGroupAllowFrom = Array.from(new Set([...effectiveGroupAllowFrom, ...storeAllowFrom]));
+
+        senderAllowedForCommands = isSenderAllowed({ senderId, senderName, allowFrom: effectiveAllowFrom });
+        groupAllowedForCommands = isSenderAllowed({ senderId, senderName, allowFrom: effectiveGroupAllowFrom });
+      }`;
+
+const replace = `      // ⚡ Bolt Optimization: Skip disk read if user is already allowed via config
+      // We only need to check the store allowlist if they aren't authorized yet.
+      // This saves a filesystem access on the hot path for authorized users.
+      if ((kind === "dm" && !senderAllowedForCommands) || (kind !== "dm" && !groupAllowedForCommands)) {
+        const storeAllowFrom = normalizeAllowList(
+          await core.channel.pairing.readAllowFromStore("zulip").catch(() => []),
+        );
+        effectiveAllowFrom = Array.from(new Set([...configAllowFrom, ...storeAllowFrom]));
+        effectiveGroupAllowFrom = Array.from(new Set([...effectiveGroupAllowFrom, ...storeAllowFrom]));
+
+        senderAllowedForCommands = isSenderAllowed({ senderId, senderName, allowFrom: effectiveAllowFrom });
+        groupAllowedForCommands = isSenderAllowed({ senderId, senderName, allowFrom: effectiveGroupAllowFrom });
+      }`;
+
+if (code.includes(search)) {
+  code = code.replace(search, replace);
+  fs.writeFileSync('src/zulip/monitor.ts', code);
+  console.log('Patched monitor.ts again');
+} else {
+  console.log('Search string not found');
+}

--- a/src/zulip/monitor.ts
+++ b/src/zulip/monitor.ts
@@ -238,7 +238,7 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
       // ⚡ Bolt Optimization: Skip disk read if user is already allowed via config
       // We only need to check the store allowlist if they aren't authorized yet.
       // This saves a filesystem access on the hot path for authorized users.
-      if (!senderAllowedForCommands || !groupAllowedForCommands) {
+      if ((kind === "dm" && !senderAllowedForCommands) || (kind !== "dm" && !groupAllowedForCommands)) {
         const storeAllowFrom = normalizeAllowList(
           await core.channel.pairing.readAllowFromStore("zulip").catch(() => []),
         );

--- a/src/zulip/monitor.ts
+++ b/src/zulip/monitor.ts
@@ -227,31 +227,27 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
         (rawText.toLowerCase().includes(botUsernameMention) ||
           core.channel.mentions.matchesMentionPatterns(rawText, mentionRegexes));
 
-      const storeAllowFrom = normalizeAllowList(
-        await core.channel.pairing.readAllowFromStore("zulip").catch(() => []),
-      );
-      
-      
-      const effectiveAllowFrom = Array.from(new Set([...configAllowFrom, ...storeAllowFrom]));
-      const effectiveGroupAllowFrom = Array.from(
-        new Set([
-          ...(configGroupAllowFrom.length > 0 ? configGroupAllowFrom : configAllowFrom),
-          ...storeAllowFrom,
-        ]),
-      );
-
       const hasControlCommand = core.channel.text.hasControlCommand(rawText, cfg);
       const isControlCommand = allowTextCommands && hasControlCommand;
-      const senderAllowedForCommands = isSenderAllowed({
-        senderId,
-        senderName,
-        allowFrom: effectiveAllowFrom,
-      });
-      const groupAllowedForCommands = isSenderAllowed({
-        senderId,
-        senderName,
-        allowFrom: effectiveGroupAllowFrom,
-      });
+
+      let effectiveAllowFrom = configAllowFrom;
+      let effectiveGroupAllowFrom = configGroupAllowFrom.length > 0 ? configGroupAllowFrom : configAllowFrom;
+      let senderAllowedForCommands = isSenderAllowed({ senderId, senderName, allowFrom: effectiveAllowFrom });
+      let groupAllowedForCommands = isSenderAllowed({ senderId, senderName, allowFrom: effectiveGroupAllowFrom });
+
+      // ⚡ Bolt Optimization: Skip disk read if user is already allowed via config
+      // We only need to check the store allowlist if they aren't authorized yet.
+      // This saves a filesystem access on the hot path for authorized users.
+      if (!senderAllowedForCommands || !groupAllowedForCommands) {
+        const storeAllowFrom = normalizeAllowList(
+          await core.channel.pairing.readAllowFromStore("zulip").catch(() => []),
+        );
+        effectiveAllowFrom = Array.from(new Set([...configAllowFrom, ...storeAllowFrom]));
+        effectiveGroupAllowFrom = Array.from(new Set([...effectiveGroupAllowFrom, ...storeAllowFrom]));
+
+        senderAllowedForCommands = isSenderAllowed({ senderId, senderName, allowFrom: effectiveAllowFrom });
+        groupAllowedForCommands = isSenderAllowed({ senderId, senderName, allowFrom: effectiveGroupAllowFrom });
+      }
       const commandGate = resolveControlCommandGate({
         useAccessGroups,
         authorizers: [


### PR DESCRIPTION
💡 What: Moved `readAllowFromStore` inside a conditional block so that it only runs if the sender or group is not already authorized by `configAllowFrom`.
🎯 Why: In `handleMessage`, `readAllowFromStore` performs a disk read. For users who are already defined in the config allowlists, this disk read is redundant and occurs for every message.
📊 Impact: Eliminates an unnecessary disk read for every message sent by pre-configured users, improving throughput on the message processing hot path.
🔬 Measurement: Run `npm run test` to confirm no functional regressions in policy enforcement.

---
*PR created automatically by Jules for task [6236924997057686304](https://jules.google.com/task/6236924997057686304) started by @niyazmft*