### PR TITLE
Support auto send on missing tool

### DIFF
--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -41,9 +41,19 @@
     "properties": {
       "zulip": {
         "type": "object",
-        "additionalProperties": true,
+        "additionalProperties": false,
         "properties": {
+          "name": { "type": "string" },
+          "capabilities": {
+            "type": "array",
+            "items": { "type": "string" }
+          },
+          "markdown": {
+            "type": "object",
+            "additionalProperties": true
+          },
           "enabled": { "type": "boolean" },
+          "configWrites": { "type": "boolean" },
           "site": { "type": "string" },
           "url": { "type": "string" },
           "realm": { "type": "string" },
@@ -68,15 +78,50 @@
           },
           "allowFrom": {
             "type": "array",
-            "items": { "type": "string" }
+            "items": { "type": ["string", "number"] }
           },
           "groupAllowFrom": {
             "type": "array",
-            "items": { "type": "string" }
+            "items": { "type": ["string", "number"] }
           },
           "groupPolicy": {
             "type": "string",
             "enum": ["allowlist", "open", "disabled"]
+          },
+          "mediaMaxMb": {
+            "type": "integer",
+            "minimum": 1
+          },
+          "reactions": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "enabled": { "type": "boolean" },
+              "clearOnFinish": { "type": "boolean" },
+              "onStart": { "type": "string" },
+              "onSuccess": { "type": "string" },
+              "onError": { "type": "string" }
+            }
+          },
+          "textChunkLimit": {
+            "type": "integer",
+            "minimum": 1
+          },
+          "chunkMode": {
+            "type": "string",
+            "enum": ["length", "newline"]
+          },
+          "blockStreaming": { "type": "boolean" },
+          "blockStreamingCoalesce": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "responsePrefix": { "type": "string" },
+          "enableAdminActions": { "type": "boolean" },
+          "autoSendOnMissingTool": { "type": "boolean" },
+          "accounts": {
+            "type": "object",
+            "additionalProperties": true
           }
         }
       }
@@ -88,7 +133,17 @@
         "type": "object",
         "additionalProperties": false,
         "properties": {
+          "name": { "type": "string" },
+          "capabilities": {
+            "type": "array",
+            "items": { "type": "string" }
+          },
+          "markdown": {
+            "type": "object",
+            "additionalProperties": true
+          },
           "enabled": { "type": "boolean" },
+          "configWrites": { "type": "boolean" },
           "site": { "type": "string" },
           "url": { "type": "string" },
           "realm": { "type": "string" },
@@ -113,16 +168,47 @@
           },
           "allowFrom": {
             "type": "array",
-            "items": { "type": "string" }
+            "items": { "type": ["string", "number"] }
           },
           "groupAllowFrom": {
             "type": "array",
-            "items": { "type": "string" }
+            "items": { "type": ["string", "number"] }
           },
           "groupPolicy": {
             "type": "string",
             "enum": ["allowlist", "open", "disabled"]
           },
+          "mediaMaxMb": {
+            "type": "integer",
+            "minimum": 1
+          },
+          "reactions": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "enabled": { "type": "boolean" },
+              "clearOnFinish": { "type": "boolean" },
+              "onStart": { "type": "string" },
+              "onSuccess": { "type": "string" },
+              "onError": { "type": "string" }
+            }
+          },
+          "textChunkLimit": {
+            "type": "integer",
+            "minimum": 1
+          },
+          "chunkMode": {
+            "type": "string",
+            "enum": ["length", "newline"]
+          },
+          "blockStreaming": { "type": "boolean" },
+          "blockStreamingCoalesce": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "responsePrefix": { "type": "string" },
+          "enableAdminActions": { "type": "boolean" },
+          "autoSendOnMissingTool": { "type": "boolean" },
           "accounts": {
             "type": "object",
             "additionalProperties": true
@@ -135,7 +221,15 @@
         "url": { "label": "Zulip URL", "sensitive": false },
         "site": { "label": "Zulip Site", "sensitive": false },
         "dmPolicy": { "label": "DM Policy" },
-        "groupPolicy": { "label": "Group Policy" }
+        "groupPolicy": { "label": "Group Policy" },
+        "blockStreaming": {
+          "label": "Block Streaming",
+          "description": "When true, replies are delivered as completed blocks. When false, plain text from the model streams through as it arrives — useful for models that don't reliably tool-call."
+        },
+        "autoSendOnMissingTool": {
+          "label": "Auto-send on missing tool call",
+          "description": "If the agent ends a run with assistant text but never invoked the messaging tool, deliver the text to the channel anyway. Default: true."
+        }
       }
     }
   }

--- a/src/config-schema.ts
+++ b/src/config-schema.ts
@@ -45,6 +45,7 @@ const ZulipAccountSchema = z.object({
   blockStreamingCoalesce: BlockStreamingCoalesceSchema.optional(),
   responsePrefix: z.string().optional(),
   enableAdminActions: z.boolean().default(false),
+  autoSendOnMissingTool: z.boolean().optional(),
 });
 
 export const ZulipConfigSchema = buildCatchallMultiAccountChannelSchema(

--- a/src/types.ts
+++ b/src/types.ts
@@ -66,6 +66,16 @@ export type ZulipAccountConfig = {
   streaming?: boolean;
   /** Outbound response prefix override for this channel/account. */
   responsePrefix?: string;
+  /**
+   * If the agent ends a turn with assistant text but never invokes the
+   * messaging tool (a common failure mode for local OSS models with weaker
+   * structured-tool-call training), the plugin will, after the run, read
+   * the latest assistantTexts from the session trajectory and dispatch
+   * them through the channel anyway.
+   *
+   * Default: true. Set to false to enforce strict tool-call semantics.
+   */
+  autoSendOnMissingTool?: boolean;
 };
 
 export type ZulipConfig = {

--- a/src/zulip/accounts.ts
+++ b/src/zulip/accounts.ts
@@ -27,6 +27,7 @@ export type ResolvedZulipAccount = {
   blockStreamingCoalesce?: ZulipAccountConfig["blockStreamingCoalesce"];
   streaming?: boolean;
   streams?: string[];
+  autoSendOnMissingTool?: boolean;
 };
 
 function resolveZulipSection(cfg: OpenClawConfig): ZulipConfig | undefined {
@@ -174,6 +175,7 @@ export function resolveZulipAccount(params: {
     blockStreamingCoalesce: merged.blockStreamingCoalesce,
     streaming: merged.streaming,
     streams: merged.streams,
+    autoSendOnMissingTool: merged.autoSendOnMissingTool,
   };
 }
 

--- a/src/zulip/fallback-reader.ts
+++ b/src/zulip/fallback-reader.ts
@@ -1,0 +1,127 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+/**
+ * Reads the latest assistant texts from a session's trajectory file.
+ *
+ * Used as a fallback path when the dispatcher's `deliver` callback was
+ * never invoked during a run — typically because the agent ended the
+ * turn with plain assistant text instead of a structured `message()`
+ * tool call. This happens with local OSS models (Qwen, Gemma, Llama)
+ * that have weaker structured-tool-call training than frontier APIs.
+ *
+ * The runtime writes a `trace.artifacts` event with `assistantTexts`
+ * immediately before `session.ended`, so by the time
+ * `dispatchReplyFromConfig` resolves, the file is flushed to disk.
+ *
+ * Returns the most recent `assistantTexts` array for the given session
+ * key, or `null` if no matching artifacts were found.
+ */
+export type FallbackReaderOptions = {
+  /** Resolved openclaw data dir (~/.openclaw by default). */
+  dataDir?: string;
+  /** Agent id (route.agentId from the runtime). */
+  agentId: string;
+  /**
+   * Session key (or session-key prefix) to match. The plugin's `route`
+   * exposes the channel-base session key (e.g.
+   * `agent:main:zulip:channel:5`), but the runtime's per-thread sessions
+   * have a longer key (e.g. `agent:main:zulip:channel:5:thread:<topic>`).
+   * We accept either: artifacts match if their `sessionKey` is exactly
+   * this value OR starts with this value followed by `:`.
+   */
+  sessionKey: string;
+  /**
+   * Only consider trajectory files modified within this many ms.
+   * Prevents historical sessions with the same key from being matched.
+   * Default: 30_000 (30 seconds).
+   */
+  maxAgeMs?: number;
+  /**
+   * Optional file-system override for tests.
+   */
+  fsImpl?: Pick<typeof fs, "readdir" | "stat" | "readFile">;
+};
+
+function sessionKeyMatches(artifactKey: unknown, target: string): boolean {
+  if (typeof artifactKey !== "string") return false;
+  if (artifactKey === target) return true;
+  return artifactKey.startsWith(target + ":");
+}
+
+const DEFAULT_MAX_AGE_MS = 30_000;
+
+function resolveSessionsDir(opts: FallbackReaderOptions): string {
+  const dataDir = opts.dataDir ?? path.join(os.homedir(), ".openclaw");
+  return path.join(dataDir, "agents", opts.agentId, "sessions");
+}
+
+export async function readLatestAssistantTexts(
+  opts: FallbackReaderOptions,
+): Promise<string[] | null> {
+  const fsi = opts.fsImpl ?? fs;
+  const sessionsDir = resolveSessionsDir(opts);
+  const maxAgeMs = opts.maxAgeMs ?? DEFAULT_MAX_AGE_MS;
+
+  let entries: string[];
+  try {
+    entries = await fsi.readdir(sessionsDir);
+  } catch {
+    return null;
+  }
+
+  const trajectoryFiles = entries.filter((n) => n.endsWith(".trajectory.jsonl"));
+  if (trajectoryFiles.length === 0) {
+    return null;
+  }
+
+  const cutoff = Date.now() - maxAgeMs;
+
+  // Stat each, keep only the recently-modified ones, sort newest first.
+  const recent: Array<{ name: string; mtimeMs: number }> = [];
+  for (const name of trajectoryFiles) {
+    try {
+      const st = await fsi.stat(path.join(sessionsDir, name));
+      if (st.mtimeMs >= cutoff) {
+        recent.push({ name, mtimeMs: st.mtimeMs });
+      }
+    } catch {
+      // Ignore unreadable entries.
+    }
+  }
+  recent.sort((a, b) => b.mtimeMs - a.mtimeMs);
+
+  for (const { name } of recent) {
+    const fullPath = path.join(sessionsDir, name);
+    let content: string;
+    try {
+      content = await fsi.readFile(fullPath, "utf8");
+    } catch {
+      continue;
+    }
+
+    // Scan lines from the end backwards for our latest trace.artifacts.
+    const lines = content.split("\n");
+    for (let i = lines.length - 1; i >= 0; i--) {
+      const line = lines[i];
+      if (!line) continue;
+      if (!line.includes("trace.artifacts")) continue;
+
+      let event: any;
+      try {
+        event = JSON.parse(line);
+      } catch {
+        continue;
+      }
+      if (event?.type !== "trace.artifacts") continue;
+      if (!sessionKeyMatches(event.sessionKey, opts.sessionKey)) continue;
+      const texts = event.data?.assistantTexts;
+      if (Array.isArray(texts) && texts.length > 0) {
+        return texts.filter((t: unknown) => typeof t === "string" && t.length > 0);
+      }
+    }
+  }
+
+  return null;
+}

--- a/src/zulip/reply-handler.ts
+++ b/src/zulip/reply-handler.ts
@@ -4,6 +4,7 @@ import { sendZulipTyping } from "./client.js";
 import { sendMessageZulip } from "./send.js";
 import { formatZulipLog, maskPII } from "./monitor-helpers.js";
 import { extractZulipTopicDirective } from "./text-utils.js";
+import { readLatestAssistantTexts } from "./fallback-reader.js";
 import type { ReplyPayload } from "openclaw/plugin-sdk/reply-payload";
 
 /**
@@ -88,12 +89,15 @@ export async function dispatchZulipReply(params: {
     },
   });
 
+  let deliveredAny = false;
+
   const { dispatcher, replyOptions, markDispatchIdle } =
     core.channel.reply.createReplyDispatcherWithTyping({
       ...prefixOptions,
       humanDelay: core.channel.reply.resolveHumanDelayConfig(cfg, route.agentId),
       onReplyStart: typingCallbacks.onReplyStart,
       deliver: async (payload: ReplyPayload) => {
+        deliveredAny = true;
         const mediaUrls = payload.mediaUrls ?? (payload.mediaUrl ? [payload.mediaUrl] : []);
         const rawText = core.channel.text.convertMarkdownTables(payload.text ?? "", tableMode);
         const { text, topic: topicOverride } = extractZulipTopicDirective(rawText);
@@ -153,6 +157,68 @@ export async function dispatchZulipReply(params: {
       }),
     );
   } finally {
+    if (!deliveredAny && !dispatchError) {
+      // Fallback path: the agent ended its turn with assistant text but
+      // never invoked the messaging tool. This is a common failure mode
+      // for local OSS models without strong structured-tool-call training.
+      // Pull the assistantTexts off the just-flushed trajectory and send
+      // them through the channel so the user gets a reply.
+      const autoSend = account.autoSendOnMissingTool ?? true;
+      if (autoSend) {
+        try {
+          const dataDir = (core as any).paths?.dataDir as string | undefined;
+          const sessionKey: string | undefined = route?.sessionKey ?? route?.mainSessionKey;
+          if (sessionKey && route?.agentId) {
+            const texts = await readLatestAssistantTexts({
+              dataDir,
+              agentId: route.agentId,
+              sessionKey,
+            });
+            if (texts && texts.length > 0) {
+              const text = texts.join("\n\n");
+              core.log?.(
+                formatZulipLog("zulip auto-send fallback engaged", {
+                  accountId: account.accountId,
+                  sessionKey,
+                  textLen: text.length,
+                }),
+              );
+              const { text: cleanText, topic: topicOverride } =
+                extractZulipTopicDirective(text);
+              const resolvedTopic = topicOverride
+                ? topicOverride.slice(0, 60)
+                : topic;
+              const chunkMode = core.channel.text.resolveChunkMode(
+                cfg,
+                "zulip",
+                account.accountId,
+              );
+              const chunks = core.channel.text.chunkMarkdownTextWithMode(
+                cleanText,
+                textLimit,
+                chunkMode,
+              );
+              for (const chunk of chunks.length > 0 ? chunks : [cleanText]) {
+                if (!chunk) continue;
+                await sendMessageZulip(to, chunk, {
+                  accountId: account.accountId,
+                  topic: resolvedTopic,
+                });
+              }
+              deliveredAny = true;
+              statusSink?.({ lastOutboundAt: Date.now() });
+            }
+          }
+        } catch (fbErr) {
+          core.error?.(
+            formatZulipLog("zulip auto-send fallback failed", {
+              accountId: account.accountId,
+              error: String(fbErr),
+            }),
+          );
+        }
+      }
+    }
     markDispatchIdle();
   }
 

--- a/test/fallback-reader.test.ts
+++ b/test/fallback-reader.test.ts
@@ -1,0 +1,193 @@
+import assert from "node:assert";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { test, describe, beforeEach, afterEach } from "node:test";
+import { readLatestAssistantTexts } from "../src/zulip/fallback-reader.ts";
+
+const AGENT_ID = "main";
+const SESSION_KEY = "agent:main:zulip:channel:5:thread:cinemas around";
+
+function mkTrajectoryLine(event: Record<string, unknown>): string {
+  return JSON.stringify(event);
+}
+
+function artifactsEvent(opts: {
+  sessionKey: string;
+  assistantTexts: string[];
+  ts?: string;
+}): string {
+  return mkTrajectoryLine({
+    type: "trace.artifacts",
+    sessionKey: opts.sessionKey,
+    ts: opts.ts ?? new Date().toISOString(),
+    data: {
+      assistantTexts: opts.assistantTexts,
+      didSendViaMessagingTool: false,
+    },
+  });
+}
+
+describe("readLatestAssistantTexts", () => {
+  let tmpDir: string;
+  let sessionsDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "zulip-fallback-test-"));
+    sessionsDir = path.join(tmpDir, "agents", AGENT_ID, "sessions");
+    await fs.mkdir(sessionsDir, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+  });
+
+  test("returns null when sessions dir doesn't exist", async () => {
+    const result = await readLatestAssistantTexts({
+      dataDir: path.join(tmpDir, "nonexistent"),
+      agentId: AGENT_ID,
+      sessionKey: SESSION_KEY,
+    });
+    assert.strictEqual(result, null);
+  });
+
+  test("returns null when no trajectory files match", async () => {
+    await fs.writeFile(
+      path.join(sessionsDir, "abc.trajectory.jsonl"),
+      artifactsEvent({ sessionKey: "different-key", assistantTexts: ["hi"] }),
+    );
+    const result = await readLatestAssistantTexts({
+      dataDir: tmpDir,
+      agentId: AGENT_ID,
+      sessionKey: SESSION_KEY,
+    });
+    assert.strictEqual(result, null);
+  });
+
+  test("matches when artifact sessionKey extends the provided base with ':thread:...'", async () => {
+    // route.sessionKey gives us the channel-base; the trajectory artifact
+    // uses the per-thread session key.
+    const baseKey = "agent:main:zulip:channel:5";
+    const threadKey = `${baseKey}:thread:large asian supermarkets`;
+    await fs.writeFile(
+      path.join(sessionsDir, "abc.trajectory.jsonl"),
+      artifactsEvent({ sessionKey: threadKey, assistantTexts: ["thread reply"] }),
+    );
+    const result = await readLatestAssistantTexts({
+      dataDir: tmpDir,
+      agentId: AGENT_ID,
+      sessionKey: baseKey,
+    });
+    assert.deepStrictEqual(result, ["thread reply"]);
+  });
+
+  test("does NOT match a different base prefix that just happens to start similarly", async () => {
+    const baseKey = "agent:main:zulip:channel:5";
+    // Same prefix-but-different scope (numerical extension)
+    const otherKey = "agent:main:zulip:channel:55:thread:other";
+    await fs.writeFile(
+      path.join(sessionsDir, "abc.trajectory.jsonl"),
+      artifactsEvent({ sessionKey: otherKey, assistantTexts: ["wrong scope"] }),
+    );
+    const result = await readLatestAssistantTexts({
+      dataDir: tmpDir,
+      agentId: AGENT_ID,
+      sessionKey: baseKey,
+    });
+    assert.strictEqual(result, null);
+  });
+
+  test("returns assistantTexts for matching session", async () => {
+    const lines = [
+      mkTrajectoryLine({ type: "session.started", sessionKey: SESSION_KEY }),
+      artifactsEvent({
+        sessionKey: SESSION_KEY,
+        assistantTexts: ["Hello world", "Second message"],
+      }),
+      mkTrajectoryLine({ type: "session.ended", sessionKey: SESSION_KEY }),
+    ];
+    await fs.writeFile(
+      path.join(sessionsDir, "abc.trajectory.jsonl"),
+      lines.join("\n"),
+    );
+    const result = await readLatestAssistantTexts({
+      dataDir: tmpDir,
+      agentId: AGENT_ID,
+      sessionKey: SESSION_KEY,
+    });
+    assert.deepStrictEqual(result, ["Hello world", "Second message"]);
+  });
+
+  test("ignores trajectory files older than maxAgeMs", async () => {
+    const filePath = path.join(sessionsDir, "old.trajectory.jsonl");
+    await fs.writeFile(
+      filePath,
+      artifactsEvent({ sessionKey: SESSION_KEY, assistantTexts: ["stale"] }),
+    );
+    // Backdate the file.
+    const oldTime = new Date(Date.now() - 5 * 60_000);
+    await fs.utimes(filePath, oldTime, oldTime);
+    const result = await readLatestAssistantTexts({
+      dataDir: tmpDir,
+      agentId: AGENT_ID,
+      sessionKey: SESSION_KEY,
+      maxAgeMs: 30_000,
+    });
+    assert.strictEqual(result, null);
+  });
+
+  test("prefers the most recently modified matching file", async () => {
+    const oldPath = path.join(sessionsDir, "old.trajectory.jsonl");
+    const newPath = path.join(sessionsDir, "new.trajectory.jsonl");
+    await fs.writeFile(
+      oldPath,
+      artifactsEvent({ sessionKey: SESSION_KEY, assistantTexts: ["old"] }),
+    );
+    // Sleep briefly so mtimes differ.
+    await new Promise((r) => setTimeout(r, 10));
+    await fs.writeFile(
+      newPath,
+      artifactsEvent({ sessionKey: SESSION_KEY, assistantTexts: ["new"] }),
+    );
+    const result = await readLatestAssistantTexts({
+      dataDir: tmpDir,
+      agentId: AGENT_ID,
+      sessionKey: SESSION_KEY,
+    });
+    assert.deepStrictEqual(result, ["new"]);
+  });
+
+  test("filters out non-string and empty entries", async () => {
+    await fs.writeFile(
+      path.join(sessionsDir, "abc.trajectory.jsonl"),
+      mkTrajectoryLine({
+        type: "trace.artifacts",
+        sessionKey: SESSION_KEY,
+        data: { assistantTexts: ["good", "", null, 42, "alsogood"] },
+      }),
+    );
+    const result = await readLatestAssistantTexts({
+      dataDir: tmpDir,
+      agentId: AGENT_ID,
+      sessionKey: SESSION_KEY,
+    });
+    assert.deepStrictEqual(result, ["good", "alsogood"]);
+  });
+
+  test("skips malformed JSON lines without failing", async () => {
+    const lines = [
+      "{not valid json",
+      artifactsEvent({ sessionKey: SESSION_KEY, assistantTexts: ["ok"] }),
+    ];
+    await fs.writeFile(
+      path.join(sessionsDir, "abc.trajectory.jsonl"),
+      lines.join("\n"),
+    );
+    const result = await readLatestAssistantTexts({
+      dataDir: tmpDir,
+      agentId: AGENT_ID,
+      sessionKey: SESSION_KEY,
+    });
+    assert.deepStrictEqual(result, ["ok"]);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a fallback delivery path for Zulip channel-routed sessions. If the agent run ends with assistant text but the dispatcher's `deliver` was never invoked (typically because the model produced plain text instead of calling the `message`/`sessions_send` tool), the plugin reads the latest `trace.artifacts` event from the session's trajectory file and dispatches `assistantTexts` through the channel via `sendMessageZulip`.

Also fixes a separate schema-drift bug: `openclaw.plugin.json#channelConfigs/zulip/schema` was missing several fields that `src/config-schema.ts` accepts (notably `blockStreaming`, `mediaMaxMb`, `reactions`, `textChunkLimit`, `chunkMode`, etc.). Bringing both in line so the gateway-level JSON-schema validation matches the runtime Zod validation.

## Why

Local OSS models (Qwen, Gemma, Llama, Mistral) reliably tool-call mid-conversation (read files, run skills) but often end the final turn with plain prose. In TUI sessions this works — the runtime streams text to the user. In channel-routed sessions, `deliver` only fires on a structured tool call, so plain-text turns produce no reply, just a typing indicator that dangles until the client times out.

Reproduced live with `qwen3.6:35b` via Ollama posting in `#bot` on a self-hosted Zulip realm: the agent ran `goplaces`, `web_search`, `read`, `exec` correctly, generated a clean answer in `assistantTexts`, but ended with `stopReason: "stop"` instead of `toolUse`, leaving `didSendViaMessagingTool: false`. After this patch the trajectory still shows `didSendViaMessagingTool: false`, but the reply lands in Zulip via the fallback.

## Configuration

New optional field (default `true`):

```jsonc
"channels": {
  "zulip": {
    "autoSendOnMissingTool": false  // disable for strict tool-call semantics
  }
}
```

## Implementation

- `src/zulip/fallback-reader.ts`: new helper that scans the agent's sessions directory for recent `.trajectory.jsonl` files, finds the latest `trace.artifacts` event matching the route's `sessionKey` (prefix-aware — channel-base routes match thread-scoped artifacts), returns `assistantTexts`. Bounded by a max-age window (default 30s) so historical sessions don't get replayed.
- `src/zulip/reply-handler.ts`: tracks whether `deliver` was called during the run; in `finally`, if not delivered and `autoSendOnMissingTool` is enabled, reads the trajectory and sends.
- `src/types.ts`, `src/config-schema.ts`, `src/zulip/accounts.ts`: thread the new `autoSendOnMissingTool` config field through.
- `openclaw.plugin.json`: schema sync with Zod + new `autoSendOnMissingTool` declaration.
- `test/fallback-reader.test.ts`: 9 unit tests covering happy path, no-match, age filtering, freshness ordering, malformed JSON tolerance, prefix-match, and prefix-collision rejection.

## Future direction

Long-term, the openclaw SDK could expose `onAssistantTextNotDelivered` (or similar) so plugins don't need to read trajectory files. Worth filing as a separate openclaw upstream issue.

## Test plan

- [x] `npm run typecheck`
- [x] `npm test` (90/90 pass, 1 skipped)
- [x] `npm run build`
- [x] Live test against self-hosted Zulip with qwen3.6:35b/Ollama — replies now land for queries the model can't tool-call

🤖 Generated with [Claude](https://claude.com/)
