### PR TITLE
Release 2026.7.5 — Simplified onboarding, aligned releases

### DIFF
--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "zulip",
   "name": "Zulip",
   "description": "OpenClaw Zulip channel plugin",
-  "version": "2026.7.4",
+  "version": "2026.7.5",
   "activation": {
     "onStartup": true
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@niyazmft/openclaw-zulip",
-  "version": "2026.7.4",
+  "version": "2026.7.5",
   "description": "OpenClaw Zulip channel plugin",
   "type": "module",
   "packageManager": "pnpm@10.32.1",


### PR DESCRIPTION
## What's New

- **Simplified onboarding flow** — README now matches the actual fresh-host experience
- **Generic gateway restart** —  instead of [32m[PM2] [39mSpawning PM2 daemon with pm2_home=/Users/niyaz/.pm2
[32m[PM2] [39mPM2 Successfully daemonized
[1m[34mUse --update-env to update environment variables[39m[22m
- **Removed redundant steps** — No more  setup, no v25.2.1 checks
- **ClawHub + GitHub aligned** — Both platforms now serve 

### Changes
- README.md: Quick Start reduced from 6 steps to 5, removed  prerequisite
- README.md: Installation uses  wizard exclusively
- README.md: Troubleshooting updated for modern host behavior
- AGENTS.md: Added 6 new troubleshooting entries from production debugging

### Version Alignment
| Platform | Version |
|---|---|
| ClawHub |  |
| GitHub |  |