### PR TITLE
Release 2026.7.7 — Zero ClawHub validation warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ GEMINI.md
 deploy.sh
 ProjectManager/
 docs/
+reports/

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2,20 +2,11 @@
   "id": "zulip",
   "name": "Zulip",
   "description": "OpenClaw Zulip channel plugin",
-  "version": "2026.7.5",
+  "version": "2026.7.7",
   "activation": {
     "onStartup": true
   },
   "channels": ["zulip"],
-  "channelEnvVars": {
-    "zulip": [
-      "ZULIP_API_KEY",
-      "ZULIP_EMAIL",
-      "ZULIP_URL",
-      "ZULIP_SITE",
-      "ZULIP_REALM"
-    ]
-  },
   "setup": {
     "providers": [
       {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@niyazmft/openclaw-zulip",
-  "version": "2026.7.5",
+  "version": "2026.7.7",
   "description": "OpenClaw Zulip channel plugin",
   "type": "module",
   "packageManager": "pnpm@10.32.1",
@@ -13,15 +13,6 @@
       "./dist/index.js"
     ],
     "setupEntry": "./dist/setup-entry.js",
-    "channelEnvVars": {
-      "zulip": [
-        "ZULIP_API_KEY",
-        "ZULIP_EMAIL",
-        "ZULIP_URL",
-        "ZULIP_SITE",
-        "ZULIP_REALM"
-      ]
-    },
     "channel": {
       "id": "zulip",
       "label": "Zulip",
@@ -33,8 +24,9 @@
     },
     "install": {
       "localPath": ".",
-      "defaultChoice": "local",
-      "minHostVersion": ">=2026.6.0"
+      "defaultChoice": "clawhub",
+      "minHostVersion": ">=2026.7.0",
+      "clawhubSpec": "@niyazmft/openclaw-zulip"
     },
     "build": {
       "openclawVersion": "2026.7.0",

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -34,6 +34,8 @@ async function startZulipMonitor(cfg: OpenClawConfig, statusSink: any) {
         statusSink: statusSink,
       }).catch((err) => {
         // Monitor exited or crashed; allow restart on next probe
+        monitorAbortController?.abort();
+        monitorAbortController = null;
       });
       break;
     }

--- a/src/group-mentions.ts
+++ b/src/group-mentions.ts
@@ -1,4 +1,4 @@
-import type { ChannelGroupContext } from "openclaw/plugin-sdk";
+import type { ChannelGroupContext } from "openclaw/plugin-sdk/channel-core";
 import { resolveZulipAccount } from "./zulip/accounts.js";
 
 export function resolveZulipGroupRequireMention(params: ChannelGroupContext): boolean | undefined {

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -1,4 +1,4 @@
-import type { PluginRuntime } from "openclaw/plugin-sdk";
+import type { PluginRuntime } from "openclaw/plugin-sdk/channel-core";
 
 let runtime: PluginRuntime | null = null;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import type { BlockStreamingCoalesceConfig, DmPolicy, GroupPolicy } from "openclaw/plugin-sdk";
+import type { BlockStreamingCoalesceConfig, DmPolicy, GroupPolicy } from "openclaw/plugin-sdk/channel-config-schema";
 
 export type ZulipChatMode = "oncall" | "onmessage" | "onchar";
 

--- a/src/zulip/dedupe-store.ts
+++ b/src/zulip/dedupe-store.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import type { PluginRuntime } from "openclaw/plugin-sdk";
+import type { PluginRuntime } from "openclaw/plugin-sdk/channel-core";
 
 export type DedupeStoreOpts = {
   accountId: string;

--- a/src/zulip/media-utils.ts
+++ b/src/zulip/media-utils.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import type { PluginRuntime } from "openclaw/plugin-sdk";
+import type { PluginRuntime } from "openclaw/plugin-sdk/channel-core";
 import { getZulipRuntime } from "../runtime.js";
 import { downloadZulipUpload } from "./uploads.js";
 import { formatZulipLog, maskPII } from "./monitor-helpers.js";

--- a/src/zulip/polling.ts
+++ b/src/zulip/polling.ts
@@ -1,4 +1,4 @@
-import type { PluginRuntime } from "openclaw/plugin-sdk";
+import type { PluginRuntime } from "openclaw/plugin-sdk/channel-core";
 import type { ZulipMessage } from "./client.js";
 import { getZulipEventsWithRetry } from "./client.js";
 import { formatZulipLog, delay, maskPII } from "./monitor-helpers.js";

--- a/src/zulip/queue-manager.ts
+++ b/src/zulip/queue-manager.ts
@@ -1,4 +1,4 @@
-import type { PluginRuntime } from "openclaw/plugin-sdk";
+import type { PluginRuntime } from "openclaw/plugin-sdk/channel-core";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";

--- a/test/dedupe-store.test.ts
+++ b/test/dedupe-store.test.ts
@@ -4,7 +4,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { ZulipDedupeStore } from "../src/zulip/dedupe-store.js";
-import type { PluginRuntime } from "openclaw/plugin-sdk";
+import type { PluginRuntime } from "openclaw/plugin-sdk/channel-core";
 
 const mockRuntime: PluginRuntime = {
   log: () => {},

--- a/types/openclaw-plugin-sdk.d.ts
+++ b/types/openclaw-plugin-sdk.d.ts
@@ -42,12 +42,14 @@ declare module "openclaw/plugin-sdk/core" {
 }
 
 declare module "openclaw/plugin-sdk/channel-core" {
+  export type PluginRuntime = any;
   export type OpenClawPluginApi = any;
   export type OpenClawConfig = any;
   export type OpenClawChannelPlugin = any;
   export type ChannelSetupResult = any;
   export type ChannelAccountSnapshot = any;
   export type ChannelMessageActionName = any;
+  export type ChannelGroupContext = any;
   export const DEFAULT_ACCOUNT_ID: string;
   export const normalizeAccountId: any;
   export const getChatChannelMeta: any;
@@ -112,6 +114,9 @@ declare module "openclaw/plugin-sdk/runtime-env" {
 }
 
 declare module "openclaw/plugin-sdk/channel-config-schema" {
+  export type BlockStreamingCoalesceConfig = any;
+  export type DmPolicy = any;
+  export type GroupPolicy = any;
   export const BlockStreamingCoalesceSchema: any;
   export const DmPolicySchema: any;
   export const GroupPolicySchema: any;


### PR DESCRIPTION
## What's Changed

- **Fix legacy-root-sdk-import**: Removed stale `dist/src/onboarding*.js` files and migrated all type imports from root barrel to focused SDK subpaths
- **Fix channel-env-vars**: Removed deprecated `channelEnvVars` from manifest (new `setup.providers[].envVars` already present)
- **Fix package-min-host-version-drift**: Updated `minHostVersion` from `>=2026.6.0` to `>=2026.7.0`
- **Fix package-install-metadata-incomplete**: Changed `defaultChoice` to `clawhub` and added `clawhubSpec`

## Validation

```bash
npx clawhub package validate .
# Plugin Inspector: PASS
# Breakages: 0
# Warnings: 0
```