### PR TITLE
fix: resolve monitor lifecycle bugs and harden security (#187, #189)

### DIFF
--- a/src/channel.ts
+++ b/src/channel.ts
@@ -8,39 +8,9 @@ import {
 } from "openclaw/plugin-sdk/channel-core";
 import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "openclaw/plugin-sdk/core";
 import { setZulipRuntime } from "./runtime.js";
-import type { OpenClawConfig } from "openclaw/plugin-sdk/channel-core";
 import type { ZulipConfig } from "./types.js";
 import { zulipMessageActions } from "./actions.js";
 
-let monitorAbortController: AbortController | null = null;
-
-async function startZulipMonitor(cfg: OpenClawConfig, statusSink: any) {
-  if (monitorAbortController && !monitorAbortController.signal.aborted) {
-    return;
-  }
-
-  const accountIds = listZulipAccountIds(cfg);
-  for (const accountId of accountIds) {
-    const account = resolveZulipAccount({ cfg, accountId });
-    if (account.enabled && account.apiKey && account.email && account.baseUrl) {
-      monitorAbortController = new AbortController();
-      monitorZulipProvider({
-        apiKey: account.apiKey,
-        email: account.email,
-        baseUrl: account.baseUrl,
-        accountId: accountId,
-        config: cfg,
-        abortSignal: monitorAbortController.signal,
-        statusSink: statusSink,
-      }).catch((err) => {
-        // Monitor exited or crashed; allow restart on next probe
-        monitorAbortController?.abort();
-        monitorAbortController = null;
-      });
-      break;
-    }
-  }
-}
 import { ZulipChannelConfigSchema } from "./config-schema.js";
 import { resolveZulipGroupRequireMention } from "./group-mentions.js";
 import { looksLikeZulipTargetId, normalizeZulipMessagingTarget } from "./normalize.js";
@@ -55,7 +25,6 @@ import {
 } from "./zulip/accounts.js";
 import { normalizeZulipBaseUrl } from "./zulip/client.js";
 import { maskPII, formatZulipLog } from "./zulip/monitor-helpers.js";
-import { monitorZulipProvider } from "./zulip/monitor.js";
 import { probeZulip } from "./zulip/probe.js";
 import { sendMessageZulip } from "./zulip/send.js";
 
@@ -196,11 +165,6 @@ export const zulipPlugin = createChatChannelPlugin<ResolvedZulipAccount>({
       const baseUrl = account.baseUrl?.trim();
       if (!apiKey || !email || !baseUrl) {
         return { ok: false, error: "apiKey, email, or url missing" };
-      }
-      
-      if ((!monitorAbortController || monitorAbortController.signal.aborted) && cfg && statusSink) {
-        startZulipMonitor(cfg as OpenClawConfig, statusSink).catch((err) => {
-        });
       }
       
       return await probeZulip(baseUrl, email, apiKey, timeoutMs);

--- a/src/zulip/client.ts
+++ b/src/zulip/client.ts
@@ -68,8 +68,27 @@ export type ZulipMessage = {
 };
 
 /**
+ * Checks whether a URL hostname resolves to an internal/private IP or
+ * well-known metadata endpoint. Used to prevent SSRF.
+ */
+export function isInternalHost(url: string): boolean {
+  try {
+    const { hostname } = new URL(url);
+    const h = hostname.toLowerCase();
+    if (["localhost", "127.0.0.1", "::1", "0.0.0.0"].includes(h)) return true;
+    if (h === "169.254.169.254") return true; // AWS metadata
+    if (/^10\./.test(h) || /^192\.168\./.test(h)) return true;
+    if (/^172\.(1[6-9]|2\d|3[01])\./.test(h)) return true;
+    return false;
+  } catch {
+    return true;
+  }
+}
+
+/**
  * Normalizes a Zulip base URL by trimming whitespace and removing trailing slashes.
  * Security: Only http:// and https:// protocols are allowed to prevent SSRF and protocol smuggling.
+ * Also rejects internal/private IP addresses to prevent SSRF to localhost or cloud metadata endpoints.
  */
 export function normalizeZulipBaseUrl(raw?: string | null): string | undefined {
   const trimmed = raw?.trim();
@@ -78,6 +97,10 @@ export function normalizeZulipBaseUrl(raw?: string | null): string | undefined {
   }
   // Security check: only allow http or https protocols.
   if (!/^https?:\/\//i.test(trimmed)) {
+    return undefined;
+  }
+  // Security check: reject internal/private IPs and metadata endpoints.
+  if (isInternalHost(trimmed)) {
     return undefined;
   }
   return trimmed.replace(/\/+$/, "");
@@ -484,12 +507,19 @@ export async function uploadZulipFile(
 ): Promise<{ url: string }> {
   const resolvedPath = path.resolve(filePath);
   const tmpDir = path.resolve(os.tmpdir());
-  const dataDir = path.resolve(getZulipRuntime().paths.dataDir);
+  const rawDataDir = getZulipRuntime().paths?.dataDir;
+  const dataDir = rawDataDir ? path.resolve(rawDataDir) : null;
 
-  if (!resolvedPath.startsWith(tmpDir + path.sep) && !resolvedPath.startsWith(dataDir + path.sep)) {
+  const allowedPaths: string[] = [tmpDir + path.sep];
+  if (dataDir) {
+    allowedPaths.push(dataDir + path.sep);
+  }
+
+  const isAllowed = allowedPaths.some((allowed) => resolvedPath.startsWith(allowed));
+  if (!isAllowed) {
       throw new Error(
           `Refusing to upload file from unauthorized path: ${filePath}. ` +
-          `Allowed paths are under ${tmpDir} or ${dataDir}.`
+          `Allowed paths are under ${tmpDir}${dataDir ? ` or ${dataDir}` : ""}.`
       );
   }
 

--- a/src/zulip/client.ts
+++ b/src/zulip/client.ts
@@ -74,7 +74,7 @@ export type ZulipMessage = {
 export function isInternalHost(url: string): boolean {
   try {
     const { hostname } = new URL(url);
-    const h = hostname.toLowerCase();
+    const h = hostname.toLowerCase().replace(/^\[|\]$/g, "");
     if (["localhost", "127.0.0.1", "::1", "0.0.0.0"].includes(h)) return true;
     if (h === "169.254.169.254") return true; // AWS metadata
     if (/^10\./.test(h) || /^192\.168\./.test(h)) return true;

--- a/src/zulip/fs-utils.ts
+++ b/src/zulip/fs-utils.ts
@@ -1,10 +1,15 @@
-import { readFile } from "node:fs/promises";
+import { lstat, readFile } from "node:fs/promises";
 
 /**
  * Reads a local file into a Buffer.
- * Security: This is a low-level utility. Callers are responsible for path validation
- * and ensuring the file is safe to read. Used primarily for uploading media to Zulip.
+ * Security: Rejects symlinks to prevent path traversal attacks. Callers are
+ * responsible for ensuring the resolved path is within an allowed directory.
+ * Used primarily for uploading media to Zulip.
  */
 export async function readSafeLocalFile(filePath: string): Promise<Buffer> {
+  const stats = await lstat(filePath);
+  if (stats.isSymbolicLink()) {
+    throw new Error("Symlinks are not allowed for file upload paths");
+  }
   return await readFile(filePath);
 }

--- a/src/zulip/send.ts
+++ b/src/zulip/send.ts
@@ -7,6 +7,7 @@ import { getZulipRuntime } from "../runtime.js";
 import { resolveZulipAccount } from "./accounts.js";
 import {
   createZulipClient,
+  isInternalHost,
   normalizeZulipBaseUrl,
   sendZulipPrivateMessage,
   sendZulipStreamMessage,
@@ -243,35 +244,46 @@ export async function sendMessageZulip(
     const isRemote = isHttpUrl(mediaUrl);
 
     if (isRemote && !isZulipHosted) {
-      const maxBytes = (cfg.agents?.defaults?.mediaMaxMb ?? 5) * 1024 * 1024;
-      const fetched = await core.channel.media.fetchRemoteMedia({
-        url: mediaUrl,
-        maxBytes,
-      });
-      const filename = (() => {
-        try {
-          return path.basename(new URL(mediaUrl).pathname) || "upload.bin";
-        } catch {
-          return "upload.bin";
-        }
-      })();
-      if (core.channel.media?.saveMediaBuffer) {
-        const saved = await core.channel.media.saveMediaBuffer(
-          fetched.buffer,
-          fetched.contentType ?? "application/octet-stream",
-          "outbound",
-          maxBytes,
-          filename,
+      // Security: reject internal/private IPs to prevent SSRF via mediaUrl
+      if (isInternalHost(mediaUrl)) {
+        core.log?.(
+          formatZulipLog("zulip outbound security warning: rejected internal mediaUrl", {
+            accountId: account.accountId,
+            mediaUrl: maskPII(mediaUrl),
+          }),
         );
-        tempFilePath = saved.path;
+        mediaUrl = undefined;
       } else {
-        tempFilePath = await writeTempFile(fetched.buffer, filename);
-        tempFileCleanup = true;
-      }
-      const upload = await uploadZulipFile(client, tempFilePath);
-      mediaUrl = upload.url;
-      if (tempFileCleanup && tempFilePath) {
-        await fsPromises.unlink(tempFilePath).catch(() => undefined);
+        const maxBytes = (cfg.agents?.defaults?.mediaMaxMb ?? 5) * 1024 * 1024;
+        const fetched = await core.channel.media.fetchRemoteMedia({
+          url: mediaUrl,
+          maxBytes,
+        });
+        const filename = (() => {
+          try {
+            return path.basename(new URL(mediaUrl).pathname) || "upload.bin";
+          } catch {
+            return "upload.bin";
+          }
+        })();
+        if (core.channel.media?.saveMediaBuffer) {
+          const saved = await core.channel.media.saveMediaBuffer(
+            fetched.buffer,
+            fetched.contentType ?? "application/octet-stream",
+            "outbound",
+            maxBytes,
+            filename,
+          );
+          tempFilePath = saved.path;
+        } else {
+          tempFilePath = await writeTempFile(fetched.buffer, filename);
+          tempFileCleanup = true;
+        }
+        const upload = await uploadZulipFile(client, tempFilePath);
+        mediaUrl = upload.url;
+        if (tempFileCleanup && tempFilePath) {
+          await fsPromises.unlink(tempFilePath).catch(() => undefined);
+        }
       }
     } else if (!isRemote) {
       core.log?.(

--- a/test/ssrf.test.ts
+++ b/test/ssrf.test.ts
@@ -1,0 +1,76 @@
+import { test, describe } from "node:test";
+import assert from "node:assert";
+import { isInternalHost, normalizeZulipBaseUrl } from "../src/zulip/client.ts";
+
+describe("SSRF protection", () => {
+  test("normalizeZulipBaseUrl rejects localhost", () => {
+    assert.strictEqual(normalizeZulipBaseUrl("http://localhost/api"), undefined);
+    assert.strictEqual(normalizeZulipBaseUrl("https://localhost:8080"), undefined);
+  });
+
+  test("normalizeZulipBaseUrl rejects 127.0.0.1", () => {
+    assert.strictEqual(normalizeZulipBaseUrl("http://127.0.0.1"), undefined);
+    assert.strictEqual(normalizeZulipBaseUrl("https://127.0.0.1:3000/zulip"), undefined);
+  });
+
+  test("normalizeZulipBaseUrl rejects ::1", () => {
+    assert.strictEqual(normalizeZulipBaseUrl("http://[::1]"), undefined);
+  });
+
+  test("normalizeZulipBaseUrl rejects 0.0.0.0", () => {
+    assert.strictEqual(normalizeZulipBaseUrl("http://0.0.0.0"), undefined);
+  });
+
+  test("normalizeZulipBaseUrl rejects AWS metadata endpoint", () => {
+    assert.strictEqual(normalizeZulipBaseUrl("http://169.254.169.254"), undefined);
+    assert.strictEqual(normalizeZulipBaseUrl("https://169.254.169.254/latest/meta-data/"), undefined);
+  });
+
+  test("normalizeZulipBaseUrl rejects 10.x.x.x", () => {
+    assert.strictEqual(normalizeZulipBaseUrl("http://10.0.0.1"), undefined);
+    assert.strictEqual(normalizeZulipBaseUrl("https://10.255.255.255"), undefined);
+  });
+
+  test("normalizeZulipBaseUrl rejects 192.168.x.x", () => {
+    assert.strictEqual(normalizeZulipBaseUrl("http://192.168.1.1"), undefined);
+    assert.strictEqual(normalizeZulipBaseUrl("https://192.168.0.100"), undefined);
+  });
+
+  test("normalizeZulipBaseUrl rejects 172.16-31.x.x", () => {
+    assert.strictEqual(normalizeZulipBaseUrl("http://172.16.0.1"), undefined);
+    assert.strictEqual(normalizeZulipBaseUrl("https://172.31.255.255"), undefined);
+    assert.strictEqual(normalizeZulipBaseUrl("http://172.20.0.1"), undefined);
+  });
+
+  test("normalizeZulipBaseUrl allows 172.15.x.x (outside private range)", () => {
+    assert.strictEqual(normalizeZulipBaseUrl("http://172.15.0.1"), "http://172.15.0.1");
+    assert.strictEqual(normalizeZulipBaseUrl("https://172.32.0.1"), "https://172.32.0.1");
+  });
+
+  test("normalizeZulipBaseUrl allows public hosts", () => {
+    assert.strictEqual(normalizeZulipBaseUrl("https://chat.example.com"), "https://chat.example.com");
+    assert.strictEqual(normalizeZulipBaseUrl("https://zulip.example.com/"), "https://zulip.example.com");
+    assert.strictEqual(normalizeZulipBaseUrl("http://myserver.localdomain"), "http://myserver.localdomain");
+  });
+
+  test("isInternalHost rejects internal IPs", () => {
+    assert.strictEqual(isInternalHost("http://localhost"), true);
+    assert.strictEqual(isInternalHost("https://127.0.0.1"), true);
+    assert.strictEqual(isInternalHost("http://10.0.0.1"), true);
+    assert.strictEqual(isInternalHost("https://192.168.1.1"), true);
+    assert.strictEqual(isInternalHost("http://172.16.0.1"), true);
+    assert.strictEqual(isInternalHost("http://169.254.169.254"), true);
+  });
+
+  test("isInternalHost allows public hosts", () => {
+    assert.strictEqual(isInternalHost("https://chat.example.com"), false);
+    assert.strictEqual(isInternalHost("https://zulip.org"), false);
+    assert.strictEqual(isInternalHost("http://8.8.8.8"), false);
+  });
+
+  test("normalizeZulipBaseUrl still rejects non-http protocols", () => {
+    assert.strictEqual(normalizeZulipBaseUrl("ftp://example.com"), undefined);
+    assert.strictEqual(normalizeZulipBaseUrl("file:///etc/passwd"), undefined);
+    assert.strictEqual(normalizeZulipBaseUrl("javascript://alert(1)"), undefined);
+  });
+});

--- a/test/symlink.test.ts
+++ b/test/symlink.test.ts
@@ -1,0 +1,38 @@
+import { test } from "node:test";
+import assert from "node:assert";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { readSafeLocalFile } from "../src/zulip/fs-utils.js";
+
+test("readSafeLocalFile rejects symlinks", async () => {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "zulip-symlink-test-"));
+  const realFile = path.join(dir, "real.txt");
+  const symlinkFile = path.join(dir, "link.txt");
+
+  await fs.writeFile(realFile, "hello");
+  await fs.symlink(realFile, symlinkFile);
+
+  try {
+    await assert.rejects(
+      readSafeLocalFile(symlinkFile),
+      /Symlinks are not allowed/,
+    );
+  } finally {
+    await fs.rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("readSafeLocalFile allows regular files", async () => {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "zulip-symlink-test-"));
+  const realFile = path.join(dir, "real.txt");
+
+  await fs.writeFile(realFile, "hello world");
+
+  try {
+    const buffer = await readSafeLocalFile(realFile);
+    assert.strictEqual(buffer.toString(), "hello world");
+  } finally {
+    await fs.rm(dir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

This PR fixes two critical issues:

### #187 — Monitor Lifecycle Bugs
- **Removed** the broken `startZulipMonitor` from `src/channel.ts`. It used a single shared `AbortController`, only started the **first** enabled account, and then `break`d — silently failing all multi-account configs.
- **Removed** the `probeAccount` side-effect that spawned monitors. Probing should be a lightweight health check, not a monitor startup trigger. This raced against `index.ts:registerFull`.
- Monitor startup is already handled correctly by `index.ts:registerFull`, which iterates all accounts with a `registerFullCalled` guard.

### #189 — Security Hardening
- **SSRF protection**: Added `isInternalHost()` to reject internal/private IPs and metadata endpoints (`169.254.169.254`, `10.x`, `192.168.x`, `172.16-31.x`, `localhost`, `127.0.0.1`, `::1`, `0.0.0.0`) in both `normalizeZulipBaseUrl` and `mediaUrl` handling.
- **Symlink traversal prevention**: `readSafeLocalFile` now uses `lstat` to reject symlinks before reading, preventing path traversal via symlink tricks.
- **dataDir guard**: `uploadZulipFile` now guards the `dataDir` check so `undefined` does not resolve to the current working directory.

### Tests
- `test/ssrf.test.ts`: 13 new tests covering all internal IP ranges and public host allowance.
- `test/symlink.test.ts`: 2 new tests for symlink rejection and regular file allowance.

### Validation
- Full `npm run check` passes: bootstrap → typecheck → build → smoke → 105 tests → package.

---

Closes #187
Closes #189
