### PR TITLE
fix: add network timeouts, fix swallowed poll errors, and clean up temp dirs (#190, #192)

### DIFF
--- a/src/zulip/client.ts
+++ b/src/zulip/client.ts
@@ -172,16 +172,24 @@ export function createZulipClient(params: {
     if (init?.body && !headers.has("Content-Type") && typeof init.body === "string") {
       headers.set("Content-Type", "application/x-www-form-urlencoded");
     }
-    const res = await fetchImpl(url, { ...init, headers });
-    if (!res.ok) {
-      const detail = await readZulipError(res);
-      const error = new Error(
-        `Zulip API ${res.status} ${res.statusText}: ${detail || "unknown error"}`,
-      ) as Error & { status?: number };
-      error.status = res.status;
-      throw error;
+    // Security/Reliability: default 30s timeout prevents indefinite hangs
+    const controller = new AbortController();
+    const timeoutMs = 30000;
+    const timeout = setTimeout(() => controller.abort(), timeoutMs);
+    try {
+      const res = await fetchImpl(url, { ...init, headers, signal: controller.signal });
+      if (!res.ok) {
+        const detail = await readZulipError(res);
+        const error = new Error(
+          `Zulip API ${res.status} ${res.statusText}: ${detail || "unknown error"}`,
+        ) as Error & { status?: number };
+        error.status = res.status;
+        throw error;
+      }
+      return (await res.json()) as T;
+    } finally {
+      clearTimeout(timeout);
     }
-    return (await res.json()) as T;
   };
 
   return { baseUrl, authHeader, fetchImpl, request };

--- a/src/zulip/monitor.ts
+++ b/src/zulip/monitor.ts
@@ -666,6 +666,17 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
           break;
         }
       } catch (err: any) {
+        core.error?.(
+          formatZulipLog("zulip monitor loop error", {
+            accountId: opts.accountId,
+            error: String(err),
+          }),
+        );
+        opts.statusSink?.({
+          connected: false,
+          lastError: String(err),
+        });
+        await delay(5000);
       }
     }
     core.log?.(

--- a/src/zulip/send.ts
+++ b/src/zulip/send.ts
@@ -283,6 +283,7 @@ export async function sendMessageZulip(
         mediaUrl = upload.url;
         if (tempFileCleanup && tempFilePath) {
           await fsPromises.unlink(tempFilePath).catch(() => undefined);
+          await fsPromises.rm(path.dirname(tempFilePath), { recursive: true, force: true }).catch(() => undefined);
         }
       }
     } else if (!isRemote) {


### PR DESCRIPTION
## Summary

This PR fixes two reliability issues:

### #190 — Network Timeouts and Swallowed Poll Loop Errors
- **Added default 30s timeout** to `request()` in `src/zulip/client.ts`. Previously, a hung Zulip server could block the Node event loop indefinitely since all API calls had no timeout.
- **Fixed empty catch block** in the monitor poll loop (`src/zulip/monitor.ts`). Previously, unexpected errors were silently swallowed, making the monitor appear alive while it stopped processing events. Now it logs the error, updates `statusSink` with `connected: false` and `lastError`, and retries after 5s.

### #192 — Temp Directory Leak in Outbound Media
- **Fixed temp directory cleanup** in `src/zulip/send.ts`. `writeTempFile` creates a temp directory via `mkdtemp`, but the cleanup code only deleted the file, never the parent directory. Now also removes the parent directory with `fs.rm({ recursive: true, force: true })`.

### Validation
- Full `npm run check` passes: bootstrap → typecheck → build → smoke → **105 tests** → package.

---

Closes #190
Closes #192
