### PR TITLE
chore: remove dead exports identified by knip audit (#193)

### DIFF
--- a/src/config-schema.ts
+++ b/src/config-schema.ts
@@ -49,7 +49,7 @@ const ZulipAccountSchema = z.object({
   autoSendOnMissingTool: z.boolean().optional(),
 });
 
-export const ZulipConfigSchema = buildCatchallMultiAccountChannelSchema(
+const ZulipConfigSchema = buildCatchallMultiAccountChannelSchema(
   ZulipAccountSchema,
 ).extend({
   streaming: z.boolean().optional(),

--- a/src/zulip/accounts.ts
+++ b/src/zulip/accounts.ts
@@ -4,9 +4,9 @@ import { normalizeAccountId } from "openclaw/plugin-sdk/core";
 import type { ZulipAccountConfig, ZulipChatMode, ZulipConfig } from "../types.js";
 import { normalizeZulipBaseUrl } from "./client.js";
 
-export type ZulipTokenSource = "env" | "config" | "none";
-export type ZulipEmailSource = "env" | "config" | "none";
-export type ZulipBaseUrlSource = "env" | "config" | "none";
+type ZulipTokenSource = "env" | "config" | "none";
+type ZulipEmailSource = "env" | "config" | "none";
+type ZulipBaseUrlSource = "env" | "config" | "none";
 
 export type ResolvedZulipAccount = {
   accountId: string;
@@ -87,7 +87,7 @@ export function getZulipEnvSecret(name: string): string | undefined {
   return process.env[name]?.trim();
 }
 
-export function hasZulipEnvSecrets(): boolean {
+function hasZulipEnvSecrets(): boolean {
   return (
     Boolean(getZulipEnvSecret("ZULIP_API_KEY")) &&
     Boolean(getZulipEnvSecret("ZULIP_EMAIL")) &&
@@ -180,7 +180,7 @@ export function resolveZulipAccount(params: {
   };
 }
 
-export function listEnabledZulipAccounts(cfg: OpenClawConfig): ResolvedZulipAccount[] {
+function listEnabledZulipAccounts(cfg: OpenClawConfig): ResolvedZulipAccount[] {
   return listZulipAccountIds(cfg)
     .map((accountId) => resolveZulipAccount({ cfg, accountId }))
     .filter((account) => account.enabled);

--- a/src/zulip/bootstrap.ts
+++ b/src/zulip/bootstrap.ts
@@ -13,7 +13,7 @@ import type { MonitorZulipOpts } from "./monitor.js";
 /**
  * Resolves the runtime environment for the Zulip monitor.
  */
-export function resolveRuntime(opts: MonitorZulipOpts): RuntimeEnv {
+function resolveRuntime(opts: MonitorZulipOpts): RuntimeEnv {
   return (
     opts.runtime ?? {
       log: console.log,

--- a/src/zulip/client.ts
+++ b/src/zulip/client.ts
@@ -25,7 +25,7 @@ export type ZulipUser = {
   is_admin?: boolean | null;
 };
 
-export type ZulipPresenceEntry = {
+type ZulipPresenceEntry = {
   status?: "active" | "idle" | string;
   timestamp?: number;
   client?: string | null;
@@ -202,7 +202,7 @@ function assertSuccess(payload: ZulipApiResponse, context: string): void {
   throw new Error(`${context}: ${payload.msg || "unknown error"}`);
 }
 
-export async function zulipRequestWithRetry<T>(
+async function zulipRequestWithRetry<T>(
   client: ZulipClient,
   path: string,
   init?: RequestInit,
@@ -358,7 +358,7 @@ export async function registerZulipQueue(
   };
 }
 
-export async function getZulipEvents(
+async function getZulipEvents(
   client: ZulipClient,
   params: {
     queueId: string;

--- a/src/zulip/media-utils.ts
+++ b/src/zulip/media-utils.ts
@@ -11,7 +11,7 @@ const checkedMediaDirs = new Set<string>();
 /**
  * Saves a Zulip media buffer to a temporary file or using the core media service.
  */
-export async function saveZulipMediaBuffer(params: {
+async function saveZulipMediaBuffer(params: {
   core: ReturnType<typeof getZulipRuntime>;
   buffer: Buffer;
   contentType: string;

--- a/src/zulip/text-utils.ts
+++ b/src/zulip/text-utils.ts
@@ -1,4 +1,4 @@
-export const DEFAULT_ONCHAR_PREFIXES = [">", "!"];
+const DEFAULT_ONCHAR_PREFIXES = [">", "!"];
 
 const HTML_TAG_REGEX = /<[^>]+>/g;
 const MENTION_REGEX = /@\*\*([^*]+)\*\*/g;


### PR DESCRIPTION
## Summary

Removes confirmed dead and unnecessary exports identified by the 2026-05-10 knip audit (`docs/audit/2026-05-10-knip-dead-code-audit.md`).

### Files changed

| File | Removed export | Reason |
|------|---------------|--------|
| `src/config-schema.ts` | `ZulipConfigSchema` | Never imported externally; used only internally to build `ZulipChannelConfigSchema` |
| `src/zulip/accounts.ts` | `hasZulipEnvSecrets`, `listEnabledZulipAccounts` | Never imported externally |
| `src/zulip/accounts.ts` | `ZulipTokenSource`, `ZulipEmailSource`, `ZulipBaseUrlSource` | Never imported externally; kept as unexported types for internal use |
| `src/zulip/bootstrap.ts` | `resolveRuntime` | Used only within the same module |
| `src/zulip/client.ts` | `zulipRequestWithRetry`, `getZulipEvents` | Used only within the same module |
| `src/zulip/client.ts` | `ZulipPresenceEntry` | Never imported externally |
| `src/zulip/media-utils.ts` | `saveZulipMediaBuffer` | Used only within the same module |
| `src/zulip/text-utils.ts` | `DEFAULT_ONCHAR_PREFIXES` | Used only within the same module |

### Validation
- Full `npm run check` passes: bootstrap → typecheck → build → smoke → **105 tests** → package.

---

Closes #193
