### PR TITLE
fix(monitor): wire gateway.startAccount for host-managed lifecycle (#187 follow-up)

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,12 +1,8 @@
 import { defineChannelPluginEntry } from "openclaw/plugin-sdk/channel-core";
 import { zulipPlugin } from "./src/channel.js";
 import { setZulipRuntime } from "./src/runtime.js";
-import { monitorZulipProvider } from "./src/zulip/monitor.js";
-import { listZulipAccountIds, resolveZulipAccount } from "./src/zulip/accounts.js";
 export { zulipPlugin } from "./src/channel.js";
 export { setZulipRuntime } from "./src/runtime.js";
-
-let registerFullCalled = false;
 
 export default defineChannelPluginEntry({
   id: "zulip",
@@ -30,46 +26,9 @@ export default defineChannelPluginEntry({
     );
   },
   registerFull(api) {
-    if (registerFullCalled) {
-      api.logger.info("[zulip] registerFull already called, skipping duplicate monitor start");
-      return;
-    }
-    registerFullCalled = true;
-
-    const { logger, runtime, config: cfg } = api;
-
+    const { logger, runtime } = api;
     api.registerChannel({ plugin: zulipPlugin });
     setZulipRuntime(runtime);
-
-    const accountIds = listZulipAccountIds(cfg);
-
-    if (accountIds.length === 0) {
-      logger.warn("[zulip] No accounts detected.");
-      return;
-    }
-
-    logger.info(`[zulip] Initializing ${accountIds.length} account(s): ${accountIds.join(", ")}`);
-
-    for (const accountId of accountIds) {
-      const account = resolveZulipAccount({ cfg, accountId });
-      const isConfigured = account?.apiKey && account?.email && account?.baseUrl;
-
-      if (isConfigured && account.enabled) {
-        logger.info(`[zulip] [${accountId}] Starting monitor for ${account.email}`);
-
-        monitorZulipProvider({
-          apiKey: account.apiKey,
-          email: account.email,
-          baseUrl: account.baseUrl,
-          accountId,
-          config: cfg,
-        }).catch((err) => {
-          logger.error(`[zulip] [${accountId}] Fatal:`, err);
-        });
-      } else {
-        logger.warn(`[zulip] [${accountId}] Missing credentials. Check apiKey, email, and baseUrl.`);
-      }
-    }
     logger.info("[zulip] Plugin registration complete.");
   },
 });

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "zulip",
   "name": "Zulip",
   "description": "OpenClaw Zulip channel plugin",
-  "version": "2026.7.7",
+  "version": "2026.8.0",
   "activation": {
     "onStartup": true
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@niyazmft/openclaw-zulip",
-  "version": "2026.7.7",
+  "version": "2026.8.0",
   "description": "OpenClaw Zulip channel plugin",
   "type": "module",
   "packageManager": "pnpm@10.32.1",

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -24,6 +24,7 @@ import {
   type ResolvedZulipAccount,
 } from "./zulip/accounts.js";
 import { normalizeZulipBaseUrl } from "./zulip/client.js";
+import { monitorZulipProvider } from "./zulip/monitor.js";
 import { maskPII, formatZulipLog } from "./zulip/monitor-helpers.js";
 import { probeZulip } from "./zulip/probe.js";
 import { sendMessageZulip } from "./zulip/send.js";
@@ -125,6 +126,30 @@ export const zulipPlugin = createChatChannelPlugin<ResolvedZulipAccount>({
       targetResolver: {
         looksLikeId: looksLikeZulipTargetId,
         hint: "<stream:NAME[:topic]|user:email|#stream[:topic]|@email>",
+      },
+    },
+    gateway: {
+      startAccount: async (ctx: any) => {
+        const account = ctx.account;
+        if (!account?.apiKey || !account?.email || !account?.baseUrl) {
+          throw new Error(
+            `Zulip not configured for account "${ctx.accountId}" (missing apiKey, email, or baseUrl)`
+          );
+        }
+        ctx.log?.info?.(`[zulip] [${ctx.accountId}] starting monitor via gateway`);
+        const statusSink = (patch: Partial<ChannelAccountSnapshot>) => {
+          ctx.setStatus?.({ accountId: ctx.accountId, ...patch });
+        };
+        await monitorZulipProvider({
+          apiKey: account.apiKey,
+          email: account.email,
+          baseUrl: account.baseUrl,
+          accountId: ctx.accountId,
+          config: ctx.cfg,
+          runtime: ctx.runtime,
+          abortSignal: ctx.abortSignal,
+          statusSink,
+        });
       },
     },
   },


### PR DESCRIPTION
## Summary

Fixes the health-monitor restart loop by moving monitor startup from `registerFull` (plugin load-time) to `gateway.startAccount` (host-managed per-account lifecycle).

### Problem

The Zulip monitor was being restarted by the host's health-monitor every ~10 minutes (`reason: stopped`). This happened because:

1. `registerFull` only runs once at plugin load — but the host expects per-account lifecycle management via `gateway.startAccount`
2. The monitor's `statusSink` was not wired to the host's `setStatus`, so `snapshot.running` stayed `false`
3. The old `registerFullCalled` guard blocked legitimate restarts after host reloads

### Changes

| File | Change |
|------|--------|
| `index.ts` | Removed monitor startup from `registerFull`. Now only registers channel + sets runtime. Removed `registerFullCalled` guard. |
| `src/channel.ts` | Added `gateway.startAccount` inside `base` to launch `monitorZulipProvider` with proper `statusSink` + `abortSignal`. |

### Validation

- Full `npm run check` passes: bootstrap → typecheck → build → smoke → **105 tests** → package.
- Deployed to lab-openclaw container: confirmed `[zulip] [default] starting monitor via gateway` in logs, no health-monitor restarts in 14+ minutes.

---

Closes #187 (follow-up fix)
