### PR TITLE
feat(monitor): placeholder editing, presence heartbeat, mark-read, subscription logging (#199, #200, #202, #203)

### DIFF
--- a/src/zulip/bootstrap.ts
+++ b/src/zulip/bootstrap.ts
@@ -5,6 +5,7 @@ import { resolveZulipAccount } from "./accounts.js";
 import {
   createZulipClient,
   fetchZulipMe,
+  fetchZulipSubscriptions,
   normalizeZulipBaseUrl,
 } from "./client.js";
 import { formatZulipLog, maskPII } from "./monitor-helpers.js";
@@ -77,6 +78,35 @@ export async function initializeZulipMonitor(params: {
     core.log?.(
       formatZulipLog("zulip admin actions enabled", {
         accountId: account.accountId,
+      }),
+    );
+  }
+
+  // Log subscriptions so admins can verify stream visibility
+  try {
+    const subscriptions = await fetchZulipSubscriptions(client);
+    const streamNames = subscriptions.map((s) => s.name).filter(Boolean);
+    if (streamNames.length > 0) {
+      core.log?.(
+        formatZulipLog("zulip subscriptions", {
+          accountId: account.accountId,
+          count: streamNames.length,
+          streams: streamNames.join(", "),
+        }),
+      );
+    } else {
+      core.log?.(
+        formatZulipLog("zulip no subscriptions", {
+          accountId: account.accountId,
+          note: "bot not subscribed to any streams — stream messages will be invisible",
+        }),
+      );
+    }
+  } catch (err) {
+    core.log?.(
+      formatZulipLog("zulip subscription check failed", {
+        accountId: account.accountId,
+        error: String(err),
       }),
     );
   }

--- a/src/zulip/client.ts
+++ b/src/zulip/client.ts
@@ -857,7 +857,7 @@ export async function updateZulipMessageFlag(
   client: ZulipClient,
   params: {
     messageId: string | number;
-    flag: "starred";
+    flag: "starred" | "read";
     op: "add" | "remove";
   },
 ): Promise<void> {

--- a/src/zulip/monitor.ts
+++ b/src/zulip/monitor.ts
@@ -8,6 +8,7 @@ import {
   deleteZulipQueue,
   registerZulipQueue,
   sendZulipTyping,
+  updateZulipMessageFlag,
   type ZulipMessage,
 } from "./client.js";
 import {
@@ -503,6 +504,27 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
       });
 
       const to = kind === "dm" ? `user:${senderId}` : `stream:${streamName || streamId}:${topic}`;
+
+      // UX: Send a "Thinking..." placeholder message immediately so users see activity.
+      // We will edit this message in-place with the actual response when ready.
+      let placeholderMessageId: string | undefined;
+      try {
+        const phResult = await sendMessageZulip(to, "🤔 Thinking...", {
+          accountId: account.accountId,
+          topic,
+        });
+        if (phResult?.messageId) {
+          placeholderMessageId = phResult.messageId;
+        }
+      } catch (err) {
+        core.log?.(
+          formatZulipLog("zulip placeholder send failed", {
+            accountId: account.accountId,
+            error: String(err),
+          }),
+        );
+      }
+
       const ctxPayload = core.channel.reply.finalizeInboundContext({
         Body: body,
         RawBody: bodyText,
@@ -602,6 +624,7 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
         to,
         statusSink: opts.statusSink,
         logVerboseMessage,
+        placeholderMessageId,
       });
 
       if (reactionsEnabled) {
@@ -646,6 +669,17 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
             logVerbose: logVerboseMessage,
           });
         }
+      }
+
+      // Mark processed message as read (best-effort)
+      try {
+        await updateZulipMessageFlag(client, {
+          messageId,
+          flag: "read",
+          op: "add",
+        });
+      } catch (err) {
+        logVerboseMessage(`zulip mark-read failed: ${String(err)}`);
       }
 
       opts.statusSink?.({ lastInboundAt: Date.now() });
@@ -693,6 +727,19 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
     }
 
     core.log?.(formatZulipLog("zulip monitor loop entering", { accountId: account.accountId }));
+
+    // Presence heartbeat: keep bot showing as 🟢 online
+    const presenceInterval = setInterval(async () => {
+      try {
+        await client.request("/users/me/presence", {
+          method: "POST",
+          body: "status=active",
+        });
+      } catch (err) {
+        logVerboseMessage(`zulip presence heartbeat failed: ${String(err)}`);
+      }
+    }, 60_000);
+
     while (!opts.abortSignal?.aborted) {
       try {
         const result = await pollOnce({
@@ -729,6 +776,8 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
         aborted: opts.abortSignal?.aborted,
       }),
     );
+
+    clearInterval(presenceInterval);
 
     if (queueManager) {
       const queue = queueManager.getQueue();

--- a/src/zulip/reply-handler.ts
+++ b/src/zulip/reply-handler.ts
@@ -1,6 +1,6 @@
 import { createTypingCallbacks } from "openclaw/plugin-sdk/channel-reply-options-runtime";
 import { logTypingFailure } from "openclaw/plugin-sdk/channel-feedback";
-import { sendZulipTyping } from "./client.js";
+import { sendZulipTyping, editZulipMessage } from "./client.js";
 import { sendMessageZulip } from "./send.js";
 import { addReactionSafe } from "./reactions.js";
 import { formatZulipLog, maskPII } from "./monitor-helpers.js";
@@ -32,6 +32,7 @@ export async function dispatchZulipReply(params: {
   to: string;
   statusSink?: (patch: any) => void;
   logVerboseMessage: (msg: string) => void;
+  placeholderMessageId?: string;
 }): Promise<unknown> {
   const {
     core,
@@ -53,6 +54,7 @@ export async function dispatchZulipReply(params: {
     to,
     statusSink,
     logVerboseMessage,
+    placeholderMessageId,
   } = params;
 
   const typingParams = isDM
@@ -91,6 +93,7 @@ export async function dispatchZulipReply(params: {
   });
 
   let deliveredAny = false;
+  let placeholderConsumed = false;
 
   const { dispatcher, replyOptions, markDispatchIdle } =
     core.channel.reply.createReplyDispatcherWithTyping({
@@ -106,25 +109,62 @@ export async function dispatchZulipReply(params: {
         if (mediaUrls.length === 0) {
           const chunkMode = core.channel.text.resolveChunkMode(cfg, "zulip", account.accountId);
           const chunks = core.channel.text.chunkMarkdownTextWithMode(text, textLimit, chunkMode);
-          for (const chunk of chunks.length > 0 ? chunks : [text]) {
-            if (!chunk) {
-              continue;
+          const nonEmptyChunks = (chunks.length > 0 ? chunks : [text]).filter(Boolean);
+          for (let idx = 0; idx < nonEmptyChunks.length; idx++) {
+            const chunk = nonEmptyChunks[idx];
+            // UX: Edit the placeholder message for the first chunk, then send new messages for the rest.
+            if (!placeholderConsumed && placeholderMessageId) {
+              placeholderConsumed = true;
+              try {
+                await editZulipMessage(client, {
+                  messageId: placeholderMessageId,
+                  content: chunk,
+                });
+              } catch (err) {
+                logVerboseMessage(
+                  `zulip placeholder edit failed: ${String(err)}; falling back to new message`,
+                );
+                await sendMessageZulip(to, chunk, {
+                  accountId: account.accountId,
+                  topic: resolvedTopic,
+                });
+              }
+            } else {
+              await sendMessageZulip(to, chunk, {
+                accountId: account.accountId,
+                topic: resolvedTopic,
+              });
             }
-            await sendMessageZulip(to, chunk, {
-              accountId: account.accountId,
-              topic: resolvedTopic,
-            });
           }
         } else {
           let first = true;
           for (const mediaUrl of mediaUrls) {
             const caption = first ? text : "";
             first = false;
-            await sendMessageZulip(to, caption, {
-              accountId: account.accountId,
-              mediaUrl,
-              topic: resolvedTopic,
-            });
+            if (!placeholderConsumed && placeholderMessageId) {
+              placeholderConsumed = true;
+              try {
+                await editZulipMessage(client, {
+                  messageId: placeholderMessageId,
+                  content: caption,
+                });
+              } catch (err) {
+                logVerboseMessage(
+                  `zulip placeholder edit failed: ${String(err)}; falling back to new message`,
+                );
+                await sendMessageZulip(to, caption, {
+                  accountId: account.accountId,
+                  mediaUrl,
+                  topic: resolvedTopic,
+                });
+              }
+            } else {
+              await sendMessageZulip(to, caption, {
+                accountId: account.accountId,
+                mediaUrl,
+                topic: resolvedTopic,
+              });
+            }
           }
         }
         statusSink?.({ lastOutboundAt: Date.now() });


### PR DESCRIPTION
## Summary

Implements 4 UX and operational improvements inspired by the zulip-hermes-integration comparison analysis.

### Changes

| Issue | Feature | Files |
|-------|---------|-------|
| **#199** | "🤔 Thinking..." placeholder editing | `src/zulip/monitor.ts`, `src/zulip/reply-handler.ts` |
| **#200** | Presence heartbeat (🟢 online) | `src/zulip/monitor.ts` |
| **#202** | Mark processed messages as read | `src/zulip/monitor.ts`, `src/zulip/client.ts` |
| **#203** | Log subscribed streams on startup | `src/zulip/bootstrap.ts`, `src/zulip/client.ts` |

### #199 — Placeholder Editing

After policy passes, the bot immediately sends a "🤔 Thinking..." placeholder message. When the AI response is ready:
- **Single chunk:** The placeholder is edited in-place with the full content
- **Multi-chunk:** The placeholder is edited with the first chunk; remaining chunks are sent as new messages
- If edit fails (e.g. message too old), falls back to sending a new message

### #200 — Presence Heartbeat

Every 60 seconds, the bot calls `POST /users/me/presence` with `status=active` so it appears 🟢 online in Zulip's user list. Interval is cleaned up on monitor exit.

### #202 — Mark Messages as Read

After successful dispatch, the bot calls `/messages/flags` with `flag=read, op=add` so processed inbound messages don't show as unread for the user.

### #203 — Subscription Logging

On startup, the bot fetches its subscriptions and logs them at info level. If not subscribed to any streams, a warning is logged to help admins debug visibility issues.

### Also Changed

- Extended `updateZulipMessageFlag` in `client.ts` to accept `flag: "read"` (previously only `"starred"` was supported).

## Validation

- Full `npm run check` passes: bootstrap → typecheck → build → smoke → **105 tests** → package.

---

Closes #199, closes #200, closes #202, closes #203
