### PR TITLE
feat(workspace): add sandboxed bot workspace for file generation and upload (#201)

### DIFF
--- a/src/zulip/workspace.ts
+++ b/src/zulip/workspace.ts
@@ -1,0 +1,176 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { uploadZulipFile, type ZulipClient } from "./client.js";
+
+export type BotWorkspaceOpts = {
+  /** Time-to-live for workspace files in milliseconds. Default: 1 hour */
+  ttlMs?: number;
+  /** Optional Zulip client for auto-upload convenience. */
+  client?: ZulipClient;
+};
+
+/**
+ * Creates a sandboxed workspace for bot-generated files.
+ *
+ * All files are written under `dataDir/workspace/`.
+ * Path traversal attempts are rejected.
+ * Files older than the configured TTL are auto-pruned on each save.
+ */
+export function createBotWorkspace(
+  dataDir: string,
+  opts: BotWorkspaceOpts = {},
+) {
+  const ttlMs = opts.ttlMs ?? 60 * 60 * 1000; // default 1 hour
+  const workspaceDir = path.resolve(dataDir, "workspace");
+  const client = opts.client;
+
+  async function ensureDir(): Promise<void> {
+    await fs.mkdir(workspaceDir, { recursive: true });
+  }
+
+  function resolveSafePath(filename: string): string {
+    const resolved = path.resolve(workspaceDir, filename);
+    const safePrefix = path.resolve(workspaceDir) + path.sep;
+    if (!resolved.startsWith(safePrefix)) {
+      throw new Error(`Path traversal rejected: ${filename}`);
+    }
+    return resolved;
+  }
+
+  async function pruneOldFiles(): Promise<void> {
+    try {
+      const entries = await fs.readdir(workspaceDir, { withFileTypes: true });
+      const now = Date.now();
+      for (const entry of entries) {
+        if (!entry.isFile()) continue;
+        const filePath = path.join(workspaceDir, entry.name);
+        try {
+          const stat = await fs.stat(filePath);
+          if (now - stat.mtimeMs > ttlMs) {
+            await fs.unlink(filePath);
+          }
+        } catch {
+          // ignore errors during pruning
+        }
+      }
+    } catch {
+      // directory may not exist yet
+    }
+  }
+
+  return {
+    /**
+     * Writes UTF-8 text to a file in the workspace.
+     * Prunes old files before writing.
+     */
+    async saveText(filename: string, content: string): Promise<string> {
+      await ensureDir();
+      await pruneOldFiles();
+      const filePath = resolveSafePath(filename);
+      await fs.writeFile(filePath, content, "utf8");
+      return filePath;
+    },
+
+    /**
+     * Writes raw bytes to a file in the workspace.
+     * Prunes old files before writing.
+     */
+    async saveBytes(filename: string, content: Buffer | Uint8Array): Promise<string> {
+      await ensureDir();
+      await pruneOldFiles();
+      const filePath = resolveSafePath(filename);
+      await fs.writeFile(filePath, content);
+      return filePath;
+    },
+
+    /**
+     * Serializes data as JSON with indentation and writes to a file.
+     * Prunes old files before writing.
+     */
+    async saveJson(filename: string, data: unknown): Promise<string> {
+      const text = JSON.stringify(data, null, 2);
+      return this.saveText(filename, text);
+    },
+
+    /**
+     * Reads a UTF-8 text file from the workspace.
+     */
+    async readText(filename: string): Promise<string> {
+      const filePath = resolveSafePath(filename);
+      return await fs.readFile(filePath, "utf8");
+    },
+
+    /**
+     * Reads raw bytes from a file in the workspace.
+     */
+    async readBytes(filename: string): Promise<Buffer> {
+      const filePath = resolveSafePath(filename);
+      return await fs.readFile(filePath);
+    },
+
+    /**
+     * Lists all files in the workspace with their sizes and modification times.
+     */
+    async listFiles(): Promise<
+      Array<{ name: string; size: number; mtime: Date }>
+    > {
+      try {
+        const entries = await fs.readdir(workspaceDir, { withFileTypes: true });
+        const files: Array<{ name: string; size: number; mtime: Date }> = [];
+        for (const entry of entries) {
+          if (!entry.isFile()) continue;
+          const stat = await fs.stat(path.join(workspaceDir, entry.name));
+          files.push({
+            name: entry.name,
+            size: stat.size,
+            mtime: stat.mtime,
+          });
+        }
+        return files;
+      } catch {
+        return [];
+      }
+    },
+
+    /**
+     * Deletes all files in the workspace.
+     */
+    async clear(): Promise<void> {
+      try {
+        const entries = await fs.readdir(workspaceDir, { withFileTypes: true });
+        for (const entry of entries) {
+          const entryPath = path.join(workspaceDir, entry.name);
+          if (entry.isFile()) {
+            await fs.unlink(entryPath);
+          } else if (entry.isDirectory()) {
+            await fs.rm(entryPath, { recursive: true });
+          }
+        }
+      } catch {
+        // directory may not exist
+      }
+    },
+
+    /**
+     * Uploads a file to Zulip and deletes the local copy.
+     * Requires `client` to have been passed in opts.
+     */
+    async upload(filename: string): Promise<string> {
+      if (!client) {
+        throw new Error(
+          "Zulip client not configured. Pass client in workspace opts.",
+        );
+      }
+      const filePath = resolveSafePath(filename);
+      const { url } = await uploadZulipFile(client, filePath);
+      try {
+        await fs.unlink(filePath);
+      } catch {
+        // best-effort cleanup
+      }
+      return url;
+    },
+  };
+}
+
+export type BotWorkspace = ReturnType<typeof createBotWorkspace>;

--- a/test/workspace.test.ts
+++ b/test/workspace.test.ts
@@ -1,0 +1,112 @@
+import assert from "node:assert";
+import { describe, it, beforeEach, afterEach } from "node:test";
+import os from "node:os";
+import path from "node:path";
+import fs from "node:fs/promises";
+import { createBotWorkspace } from "../src/zulip/workspace.js";
+
+describe("BotWorkspace", () => {
+  let dataDir: string;
+  let ws: ReturnType<typeof createBotWorkspace>;
+
+  beforeEach(async () => {
+    dataDir = await fs.mkdtemp(path.join(os.tmpdir(), "zulip-ws-test-"));
+    ws = createBotWorkspace(dataDir, { ttlMs: 1000 }); // 1s TTL for fast tests
+  });
+
+  afterEach(async () => {
+    try {
+      await fs.rm(dataDir, { recursive: true });
+    } catch {
+      // ignore
+    }
+  });
+
+  it("saves and reads text files", async () => {
+    const filePath = await ws.saveText("hello.txt", "Hello World");
+    assert.ok(filePath.includes("workspace"));
+    const content = await ws.readText("hello.txt");
+    assert.strictEqual(content, "Hello World");
+  });
+
+  it("saves and reads bytes", async () => {
+    const buffer = Buffer.from([0x00, 0x01, 0x02, 0x03]);
+    await ws.saveBytes("data.bin", buffer);
+    const read = await ws.readBytes("data.bin");
+    assert.ok(buffer.equals(read));
+  });
+
+  it("saves JSON with indentation", async () => {
+    await ws.saveJson("config.json", { key: "value", nested: { num: 42 } });
+    const content = await ws.readText("config.json");
+    const parsed = JSON.parse(content);
+    assert.deepStrictEqual(parsed, { key: "value", nested: { num: 42 } });
+    assert.ok(content.includes("\n"), "JSON should be indented with actual newlines");
+  });
+
+  it("lists files with metadata", async () => {
+    await ws.saveText("a.txt", "A");
+    await ws.saveText("b.txt", "B");
+    const files = await ws.listFiles();
+    assert.strictEqual(files.length, 2);
+    assert.ok(files.every((f) => typeof f.size === "number" && f.mtime instanceof Date));
+  });
+
+  it("clears all files", async () => {
+    await ws.saveText("a.txt", "A");
+    await ws.saveText("b.txt", "B");
+    await ws.clear();
+    const files = await ws.listFiles();
+    assert.strictEqual(files.length, 0);
+  });
+
+  it("rejects path traversal attempts", async () => {
+    await assert.rejects(
+      () => ws.saveText("../../etc/passwd", "evil"),
+      /Path traversal rejected/,
+    );
+  });
+
+  it("rejects path traversal with dot-dot", async () => {
+    await assert.rejects(
+      () => ws.saveText("foo/../../../etc/passwd", "evil"),
+      /Path traversal rejected/,
+    );
+  });
+
+  it("prunes old files on save", async () => {
+    // Create a file manually with an old mtime
+    const workspaceDir = path.join(dataDir, "workspace");
+    await fs.mkdir(workspaceDir, { recursive: true });
+    const oldFile = path.join(workspaceDir, "old.txt");
+    await fs.writeFile(oldFile, "old content");
+    const past = new Date(Date.now() - 5000); // 5 seconds ago
+    await fs.utimes(oldFile, past, past);
+
+    // Now save a new file — should trigger prune
+    await ws.saveText("new.txt", "new content");
+
+    const files = await ws.listFiles();
+    const names = files.map((f) => f.name);
+    assert.ok(!names.includes("old.txt"), "old file should have been pruned");
+    assert.ok(names.includes("new.txt"), "new file should exist");
+  });
+
+  it("returns empty list when workspace does not exist", async () => {
+    // Create a fresh workspace with no prior files
+    const freshWs = createBotWorkspace(
+      await fs.mkdtemp(path.join(os.tmpdir(), "zulip-ws-empty-")),
+    );
+    const files = await freshWs.listFiles();
+    assert.deepStrictEqual(files, []);
+    await fs.rm(dataDir, { recursive: true }).catch(() => {});
+  });
+
+  it("upload fails without client", async () => {
+    await ws.saveText("report.csv", "id,value\n1,42");
+    await assert.rejects(
+      () => ws.upload("report.csv"),
+      /Zulip client not configured/,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Adds `BotWorkspace` — a sandboxed file utility for AI-generated content with auto-cleanup and Zulip upload integration.

## Features

| Method | Description |
|--------|-------------|
| `saveText(filename, content)` | Write UTF-8 text |
| `saveBytes(filename, content)` | Write raw bytes |
| `saveJson(filename, data)` | Serialize JSON with indentation |
| `readText(filename)` | Read UTF-8 text back |
| `readBytes(filename)` | Read raw bytes back |
| `listFiles()` | List files with size and modification time |
| `clear()` | Delete all workspace files and subdirectories |
| `upload(filename)` | Upload to Zulip and auto-delete local file |

## Security

- All paths resolved under `dataDir/workspace/` only
- Path traversal attempts (`../../etc/passwd`) are rejected with explicit error
- File operations use `path.resolve()` + `startsWith()` validation

## Maintenance

- **Auto-prune:** Files older than configurable TTL are deleted on each save (default: 1 hour)
- TTL is configurable via `opts.ttlMs` in `createBotWorkspace(dataDir, opts)`

## Usage

```ts
import { createBotWorkspace } from "./zulip/workspace.js";

const ws = createBotWorkspace(core.paths.dataDir, {
  ttlMs: 60 * 60 * 1000, // 1 hour
  client, // optional Zulip client for upload()
});

const filePath = await ws.saveText("report.csv", "id,value\n1,42");
// ... later ...
const url = await ws.upload("report.csv"); // uploads + auto-deletes
```

## Validation

- **10 new tests** covering save/read, JSON, pruning, path traversal, clear, list, and upload without client
- Full `npm run check` passes: bootstrap → typecheck → build → smoke → **115 tests** → package

---

Closes #201
