### PR TITLE
chore(monitor): remove presence heartbeat — Zulip API rejects bot requests (#200)

### DIFF
--- a/src/zulip/monitor.ts
+++ b/src/zulip/monitor.ts
@@ -727,19 +727,6 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
     }
 
     core.log?.(formatZulipLog("zulip monitor loop entering", { accountId: account.accountId }));
-
-    // Presence heartbeat: keep bot showing as 🟢 online
-    const presenceInterval = setInterval(async () => {
-      try {
-        await client.request("/users/me/presence", {
-          method: "POST",
-          body: "status=active",
-        });
-      } catch (err) {
-        logVerboseMessage(`zulip presence heartbeat failed: ${String(err)}`);
-      }
-    }, 60_000);
-
     while (!opts.abortSignal?.aborted) {
       try {
         const result = await pollOnce({
@@ -776,8 +763,6 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
         aborted: opts.abortSignal?.aborted,
       }),
     );
-
-    clearInterval(presenceInterval);
 
     if (queueManager) {
       const queue = queueManager.getQueue();


### PR DESCRIPTION
Zulip's POST /users/me/presence endpoint returns 400 for bot accounts:\n\n```json\n{"result":"error","msg":"This endpoint does not accept bot requests.","code":"BAD_REQUEST"}\n```\n\nBot accounts cannot update presence status in Zulip. The heartbeat code was silently failing every 60 seconds without any visible effect.\n\nRemoves the dead code from src/zulip/monitor.ts.\n\nRefs: #200 (closed as wontfix — platform limitation)