### PR TITLE
chore: bump version to 2026.8.1

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,9 +112,9 @@ Migration complete as of v2026.7.0:
 
 ## Troubleshooting
 
-- **Health-monitor restarts every ~5 min** with `reason: stopped`: Fixed in v2026.8.0+. `gateway.startAccount` must be placed inside the `base` parameter of `createChatChannelPlugin`, not at the top level. The host checks `snapshot.running` to decide if channel is alive.
+- **Health-monitor restarts every ~5 min** with `reason: stopped`: Fixed in v2026.8.1+. `gateway.startAccount` must be placed inside the `base` parameter of `createChatChannelPlugin`, not at the top level. The host checks `snapshot.running` to decide if channel is alive.
 - **Monitor never starts after hot reload / wizard config**: If `startZulipMonitor` creates an `AbortController` before validating credentials, and credentials are missing at startup, the controller blocks all future starts. Only create the controller **after** credential validation, right before launching the actual monitor loop.
-- **Host calls `registerFull` twice**: Fixed in v2026.8.0+ with a module-level `registerFullCalled` guard. This is normal host behavior.
+- **Host calls `registerFull` twice**: Fixed in v2026.8.1+ with a module-level `registerFullCalled` guard. This is normal host behavior.
 - **"Invalid config: must not have additional properties: streaming"**: The host's `openclaw channels add` wizard writes `"streaming": true` to the config. If your manifest JSON Schema has `"additionalProperties": false` and `streaming` isn't in `properties`, config validation fails. Add `streaming` to BOTH `configSchema` and `channelConfigs.schema` in `openclaw.plugin.json`.
 - **`readAllowFromStore(channelName)` throws** "invalid pairing channel: expected non-empty string; got undefined": SDK bug in host `2026.7.1`. Workaround: read `credentials/zulip-{accountId}-allowFrom.json` directly from the data directory.
 - **Dedupe store blocks re-processing across restarts**: The dedupe file at `/tmp/openclaw-zulip/zulip_dedupe_default.json` survives container restarts. Clear it when testing fresh message flows.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Calendar Versioning](https://calver.org/) in the format `YYYY.M.PATCH`.
 
-## [2026.8.0] - 2026-07-21
+## [2026.8.1] - 2026-07-21
 
 ### Added
 - **Placeholder editing** (#199): Bot shows "🤔 Thinking..." placeholder immediately, replaces it with actual response when ready

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OpenClaw Zulip Bridge
 
-[![Version](https://img.shields.io/badge/version-2026.8.0-blue)](https://github.com/niyazmft/openclaw-zulip-bridge/releases)
+[![Version](https://img.shields.io/badge/version-2026.8.1-blue)](https://github.com/niyazmft/openclaw-zulip-bridge/releases)
 [![OpenClaw](https://img.shields.io/badge/OpenClaw-%3E%3D2026.6.0-green)](https://openclaw.ai)
 [![Node.js](https://img.shields.io/badge/Node.js-22%2B-brightgreen)](https://nodejs.org)
 [![pnpm](https://img.shields.io/badge/pnpm-10.32.1-orange)](https://pnpm.io)
@@ -354,13 +354,13 @@ openclaw plugins install ./ --force
 
 ### Health-monitor restarting every ~10 min with `reason: stopped`
 
-**Fixed in v2026.8.0+.** The monitor now starts via `gateway.startAccount` inside the plugin's `base` parameter, so the host properly wires `statusSink` and `abortSignal`.
+**Fixed in v2026.8.1+.** The monitor now starts via `gateway.startAccount` inside the plugin's `base` parameter, so the host properly wires `statusSink` and `abortSignal`.
 
 If you still see this on an older version, upgrade to the latest release.
 
 ### "registerFull already called, skipping duplicate monitor start"
 
-**Status:** Harmless in v2026.8.0+. The plugin now has a module-level `registerFullCalled` guard.
+**Status:** Harmless in v2026.8.1+. The plugin now has a module-level `registerFullCalled` guard.
 
 ### Queue Registration Fails
 Verify credentials with `openclaw channels add` and re-enter them.

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "zulip",
   "name": "Zulip",
   "description": "OpenClaw Zulip channel plugin",
-  "version": "2026.8.0",
+  "version": "2026.8.1",
   "activation": {
     "onStartup": true
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@niyazmft/openclaw-zulip",
-  "version": "2026.8.0",
+  "version": "2026.8.1",
   "description": "OpenClaw Zulip channel plugin",
   "type": "module",
   "packageManager": "pnpm@10.32.1",


### PR DESCRIPTION
Version bump from 2026.8.0 to 2026.8.1 across all files.\n\n### Changes\n- package.json: 2026.8.0 → 2026.8.1\n- openclaw.plugin.json: 2026.8.0 → 2026.8.1\n- README.md: version badge updated\n- CHANGELOG.md: release entry renamed\n- AGENTS.md: version references updated