### PR TITLE
chore: bump version to 2026.8.2

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,9 +112,9 @@ Migration complete as of v2026.7.0:
 
 ## Troubleshooting
 
-- **Health-monitor restarts every ~5 min** with `reason: stopped`: Fixed in v2026.8.1+. `gateway.startAccount` must be placed inside the `base` parameter of `createChatChannelPlugin`, not at the top level. The host checks `snapshot.running` to decide if channel is alive.
+- **Health-monitor restarts every ~5 min** with `reason: stopped`: Fixed in v2026.8.2+. `gateway.startAccount` must be placed inside the `base` parameter of `createChatChannelPlugin`, not at the top level. The host checks `snapshot.running` to decide if channel is alive.
 - **Monitor never starts after hot reload / wizard config**: If `startZulipMonitor` creates an `AbortController` before validating credentials, and credentials are missing at startup, the controller blocks all future starts. Only create the controller **after** credential validation, right before launching the actual monitor loop.
-- **Host calls `registerFull` twice**: Fixed in v2026.8.1+ with a module-level `registerFullCalled` guard. This is normal host behavior.
+- **Host calls `registerFull` twice**: Fixed in v2026.8.2+ with a module-level `registerFullCalled` guard. This is normal host behavior.
 - **"Invalid config: must not have additional properties: streaming"**: The host's `openclaw channels add` wizard writes `"streaming": true` to the config. If your manifest JSON Schema has `"additionalProperties": false` and `streaming` isn't in `properties`, config validation fails. Add `streaming` to BOTH `configSchema` and `channelConfigs.schema` in `openclaw.plugin.json`.
 - **`readAllowFromStore(channelName)` throws** "invalid pairing channel: expected non-empty string; got undefined": SDK bug in host `2026.7.1`. Workaround: read `credentials/zulip-{accountId}-allowFrom.json` directly from the data directory.
 - **Dedupe store blocks re-processing across restarts**: The dedupe file at `/tmp/openclaw-zulip/zulip_dedupe_default.json` survives container restarts. Clear it when testing fresh message flows.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,40 @@ and this project adheres to [Calendar Versioning](https://calver.org/) in the fo
 ### Known Limitations
 - **Bot presence** (#200): Zulip API rejects `POST /users/me/presence` for bot accounts. Bots cannot show as "online" in Zulip. This is a platform limitation.
 
+## [2026.8.2] - 2026-07-21
+
+### Added
+- **Placeholder editing** (#199): Bot shows "🤔 Thinking..." placeholder immediately, replaces it with actual response when ready
+- **Mark messages as read** (#202): Automatically marks user messages as read after processing
+- **Subscription logging** (#203): Logs subscribed streams on monitor startup for debugging visibility
+- **Bot workspace** (#201): Sandboxed file storage for generated/downloaded files under `data/zulip-workspace/`
+- **Typing indicators** (#191): Best-effort typing indicators during AI generation (60s TTL)
+- **Robot fallback reaction** (#191): Shows 🤖 when message processing starts (reactions feature)
+- **Error explanation reactions** (#191): Shows ❌ with human-readable tooltip when errors occur
+- **Network timeouts** (#190): All Zulip API requests now have explicit timeout handling (30s connect, 60s read, 90s send)
+- **Cached allowlist store** (#188): `allowFrom`/`groupAllowFrom` fetched once at monitor init with 30s TTL
+- **Deferred attachment downloads** (#188): Media downloads happen asynchronously after policy passes, not blocking inbound dispatch
+- **SSRF protection** (#189): `normalizeZulipBaseUrl` rejects internal IPs, localhost, and AWS metadata endpoints
+- **Path traversal protection** (#189): `downloadZulipUpload` sanitizes filenames from Content-Disposition
+- **Symlink protection** (#189): `readSafeLocalFile` rejects symlinks before reading
+- **Security URL encoding** (#189): All Zulip API endpoints with path parameters now properly URL-encode IDs
+
+### Fixed
+- **Health-monitor restarts** (#187): Fixed by placing `gateway.startAccount` inside `createChatChannelPlugin` params.base
+- **Swallowed poll errors** (#190): Poll loop errors are now logged instead of silently dropped
+- **Temp directory leak** (#192): Uniquely-named temp dirs are cleaned up after processing
+- **Dead code removal** (#193): Removed unused exports identified by knip audit (~15 functions)
+- **registerFull duplicate guard** (#198): Prevents duplicate monitor starts from host calling `registerFull` twice
+
+### Changed
+- **Monitor lifecycle** (#187): Monitor now starts via `gateway.startAccount` (host-managed) instead of `registerFull`
+- **Project structure**: Added `src/zulip/workspace.ts` for bot file storage
+- **Test suite**: Grew from ~20 to 115 tests (including SSRF, symlink, workspace tests)
+- **Build**: Now requires `npm run build` before smoke/package checks (enforced by CI)
+
+### Known Limitations
+- **Bot presence** (#200): Zulip API rejects `POST /users/me/presence` for bot accounts. Bots cannot show as "online" in Zulip. This is a platform limitation.
+
 ## [2026.5.1] - 2026-05-01
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OpenClaw Zulip Bridge
 
-[![Version](https://img.shields.io/badge/version-2026.8.1-blue)](https://github.com/niyazmft/openclaw-zulip-bridge/releases)
+[![Version](https://img.shields.io/badge/version-2026.8.2-blue)](https://github.com/niyazmft/openclaw-zulip-bridge/releases)
 [![OpenClaw](https://img.shields.io/badge/OpenClaw-%3E%3D2026.6.0-green)](https://openclaw.ai)
 [![Node.js](https://img.shields.io/badge/Node.js-22%2B-brightgreen)](https://nodejs.org)
 [![pnpm](https://img.shields.io/badge/pnpm-10.32.1-orange)](https://pnpm.io)
@@ -354,13 +354,13 @@ openclaw plugins install ./ --force
 
 ### Health-monitor restarting every ~10 min with `reason: stopped`
 
-**Fixed in v2026.8.1+.** The monitor now starts via `gateway.startAccount` inside the plugin's `base` parameter, so the host properly wires `statusSink` and `abortSignal`.
+**Fixed in v2026.8.2+.** The monitor now starts via `gateway.startAccount` inside the plugin's `base` parameter, so the host properly wires `statusSink` and `abortSignal`.
 
 If you still see this on an older version, upgrade to the latest release.
 
 ### "registerFull already called, skipping duplicate monitor start"
 
-**Status:** Harmless in v2026.8.1+. The plugin now has a module-level `registerFullCalled` guard.
+**Status:** Harmless in v2026.8.2+. The plugin now has a module-level `registerFullCalled` guard.
 
 ### Queue Registration Fails
 Verify credentials with `openclaw channels add` and re-enter them.

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "zulip",
   "name": "Zulip",
   "description": "OpenClaw Zulip channel plugin",
-  "version": "2026.8.1",
+  "version": "2026.8.2",
   "activation": {
     "onStartup": true
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@niyazmft/openclaw-zulip",
-  "version": "2026.8.1",
+  "version": "2026.8.2",
   "description": "OpenClaw Zulip channel plugin",
   "type": "module",
   "packageManager": "pnpm@10.32.1",


### PR DESCRIPTION
Version bump from 2026.8.1 to 2026.8.2 across all files.\n\n### Changes\n- package.json: 2026.8.1 → 2026.8.2\n- openclaw.plugin.json: 2026.8.1 → 2026.8.2\n- README.md: version badge and troubleshooting references updated\n- CHANGELOG.md: release entry renamed to 2026.8.2\n- AGENTS.md: version references updated