### PR TITLE
fix(actions): require explicit confirmation for destructive operations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,9 +112,9 @@ Migration complete as of v2026.7.0:
 
 ## Troubleshooting
 
-- **Health-monitor restarts every ~5 min** with `reason: stopped`: Fixed in v2026.8.2+. `gateway.startAccount` must be placed inside the `base` parameter of `createChatChannelPlugin`, not at the top level. The host checks `snapshot.running` to decide if channel is alive.
+- **Health-monitor restarts every ~5 min** with `reason: stopped`: Fixed in v2026.8.3+. `gateway.startAccount` must be placed inside the `base` parameter of `createChatChannelPlugin`, not at the top level. The host checks `snapshot.running` to decide if channel is alive.
 - **Monitor never starts after hot reload / wizard config**: If `startZulipMonitor` creates an `AbortController` before validating credentials, and credentials are missing at startup, the controller blocks all future starts. Only create the controller **after** credential validation, right before launching the actual monitor loop.
-- **Host calls `registerFull` twice**: Fixed in v2026.8.2+ with a module-level `registerFullCalled` guard. This is normal host behavior.
+- **Host calls `registerFull` twice**: Fixed in v2026.8.3+ with a module-level `registerFullCalled` guard. This is normal host behavior.
 - **"Invalid config: must not have additional properties: streaming"**: The host's `openclaw channels add` wizard writes `"streaming": true` to the config. If your manifest JSON Schema has `"additionalProperties": false` and `streaming` isn't in `properties`, config validation fails. Add `streaming` to BOTH `configSchema` and `channelConfigs.schema` in `openclaw.plugin.json`.
 - **`readAllowFromStore(channelName)` throws** "invalid pairing channel: expected non-empty string; got undefined": SDK bug in host `2026.7.1`. Workaround: read `credentials/zulip-{accountId}-allowFrom.json` directly from the data directory.
 - **Dedupe store blocks re-processing across restarts**: The dedupe file at `/tmp/openclaw-zulip/zulip_dedupe_default.json` survives container restarts. Clear it when testing fresh message flows.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OpenClaw Zulip Bridge
 
-[![Version](https://img.shields.io/badge/version-2026.8.2-blue)](https://github.com/niyazmft/openclaw-zulip-bridge/releases)
+[![Version](https://img.shields.io/badge/version-2026.8.3-blue)](https://github.com/niyazmft/openclaw-zulip-bridge/releases)
 [![OpenClaw](https://img.shields.io/badge/OpenClaw-%3E%3D2026.6.0-green)](https://openclaw.ai)
 [![Node.js](https://img.shields.io/badge/Node.js-22%2B-brightgreen)](https://nodejs.org)
 [![pnpm](https://img.shields.io/badge/pnpm-10.32.1-orange)](https://pnpm.io)
@@ -354,13 +354,13 @@ openclaw plugins install ./ --force
 
 ### Health-monitor restarting every ~10 min with `reason: stopped`
 
-**Fixed in v2026.8.2+.** The monitor now starts via `gateway.startAccount` inside the plugin's `base` parameter, so the host properly wires `statusSink` and `abortSignal`.
+**Fixed in v2026.8.3+.** The monitor now starts via `gateway.startAccount` inside the plugin's `base` parameter, so the host properly wires `statusSink` and `abortSignal`.
 
 If you still see this on an older version, upgrade to the latest release.
 
 ### "registerFull already called, skipping duplicate monitor start"
 
-**Status:** Harmless in v2026.8.2+. The plugin now has a module-level `registerFullCalled` guard.
+**Status:** Harmless in v2026.8.3+. The plugin now has a module-level `registerFullCalled` guard.
 
 ### Queue Registration Fails
 Verify credentials with `openclaw channels add` and re-enter them.
@@ -373,6 +373,38 @@ Default requires @mentions. Check your `chatmode` setting.
 
 ### Typing indicator TTL exceeded
 The typing indicator auto-stops after 60 seconds if the response takes longer. This is expected behavior.
+
+---
+
+## Security & Permissions
+
+### Destructive Actions
+
+The following actions require **explicit confirmation** (`confirm: true`) to prevent accidental execution by AI agents:
+
+| Action | Confirmation Required | Admin Privilege Required | Description |
+|--------|----------------------|-------------------------|-------------|
+| `delete` | ✅ `confirm: true` | ❌ No | Permanently deletes a Zulip message |
+| `channel-delete` | ✅ `confirm: true` | ✅ Yes | Deletes a Zulip stream/channel |
+| `user-deactivate` | ✅ `confirm: true` | ✅ Yes | Deactivates a Zulip user account |
+| `user-reactivate` | ✅ `confirm: true` | ✅ Yes | Reactivates a Zulip user account |
+| `org-settings-edit` | ✅ `confirm: true` | ✅ Yes | Updates organization settings |
+
+### Admin Actions Gate
+
+Actions marked "Admin Privilege Required" are additionally protected by:
+
+1. **`enableAdminActions: true`** in your Zulip channel config
+2. **The bot account must have Zulip admin privileges** on the server
+
+Without both safeguards, admin actions will throw an error. This prevents accidental delegation of destructive operations to agents that should not have them.
+
+### Best Practices
+
+- Use a **least-privilege bot account** (Generic Bot, not Admin Bot)
+- Keep `enableAdminActions: false` unless you explicitly need stream management or user lifecycle operations
+- Restrict `streams` and `allowFrom` to minimize exposure
+- Avoid delegating this plugin to agents that should not delete messages/channels or alter users and organization settings
 
 ---
 

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "zulip",
   "name": "Zulip",
   "description": "OpenClaw Zulip channel plugin",
-  "version": "2026.8.2",
+  "version": "2026.8.3",
   "activation": {
     "onStartup": true
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@niyazmft/openclaw-zulip",
-  "version": "2026.8.2",
+  "version": "2026.8.3",
   "description": "OpenClaw Zulip channel plugin",
   "type": "module",
   "packageManager": "pnpm@10.32.1",

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -599,6 +599,13 @@ export const zulipMessageActions: ChannelMessageActionAdapter = {
 
     if (action === "channel-delete") {
       requireAdminActionsEnabled(account);
+      const confirm = readBooleanParam(params, "confirm", "confirmed", "acknowledge");
+      if (confirm !== true) {
+        throw new Error(
+          "Channel deletion requires confirm: true. " +
+          "This action permanently removes the stream and its message history from Zulip.",
+        );
+      }
       const streamIdOrName = readStreamId(params);
       // Resolve stream name to ID if necessary
       const streamId = await resolveZulipStreamId(client, streamIdOrName);
@@ -625,6 +632,13 @@ export const zulipMessageActions: ChannelMessageActionAdapter = {
     if ((action as string) === "user-deactivate") {
       requireAdminActionsEnabled(account);
       await requireZulipAdmin(client);
+      const confirm = readBooleanParam(params, "confirm", "confirmed", "acknowledge");
+      if (confirm !== true) {
+        throw new Error(
+          "User deactivation requires confirm: true. " +
+          "This action disables the user's Zulip account and removes their login access.",
+        );
+      }
       const userId = readUserIdParam(params);
       await deactivateZulipUser(client, userId);
       return jsonResult({ ok: true, userId, deactivated: true });
@@ -633,6 +647,13 @@ export const zulipMessageActions: ChannelMessageActionAdapter = {
     if ((action as string) === "user-reactivate") {
       requireAdminActionsEnabled(account);
       await requireZulipAdmin(client);
+      const confirm = readBooleanParam(params, "confirm", "confirmed", "acknowledge");
+      if (confirm !== true) {
+        throw new Error(
+          "User reactivation requires confirm: true. " +
+          "This action restores a previously deactivated Zulip user account.",
+        );
+      }
       const userId = readUserIdParam(params);
       await reactivateZulipUser(client, userId);
       return jsonResult({ ok: true, userId, reactivated: true });
@@ -646,6 +667,13 @@ export const zulipMessageActions: ChannelMessageActionAdapter = {
     if ((action as string) === "org-settings-edit") {
       requireAdminActionsEnabled(account);
       await requireZulipAdmin(client);
+      const confirm = readBooleanParam(params, "confirm", "confirmed", "acknowledge");
+      if (confirm !== true) {
+        throw new Error(
+          "Organization settings update requires confirm: true. " +
+          "This action modifies global Zulip realm configuration.",
+        );
+      }
       const updates = readRealmUpdateParams(params);
       await updateZulipRealm(client, updates);
       return jsonResult({ ok: true, updated: Object.keys(updates) });
@@ -748,6 +776,13 @@ export const zulipMessageActions: ChannelMessageActionAdapter = {
     }
 
     if (action === "delete") {
+      const confirm = readBooleanParam(params, "confirm", "confirmed", "acknowledge");
+      if (confirm !== true) {
+        throw new Error(
+          "Message deletion requires confirm: true. " +
+          "This action permanently removes the message from Zulip.",
+        );
+      }
       const messageId = readMessageId(params);
       await deleteZulipMessage(client, { messageId });
       return jsonResult({ ok: true, deleted: messageId });


### PR DESCRIPTION
Adds artifact-level confirmation (`confirm: true`) to all destructive Zulip actions flagged by ClawHub security scan:\n\n### Changes\n- **`delete`** (message): requires `confirm: true`\n- **`channel-delete`**: requires `confirm: true` + admin\n- **`user-deactivate`**: requires `confirm: true` + admin\n- **`user-reactivate`**: requires `confirm: true` + admin\n- **`org-settings-edit`**: requires `confirm: true` + admin\n\n### Documentation\n- Added comprehensive **Security & Permissions** section to README.md\n- Documents confirmation requirements and admin gate safeguards\n\n### Why\nClawHub ClawScan flagged these actions as requiring artifact-level confirmation (SQP-2, SDI-1/2). This fix addresses the `scan:suspicious` finding from v2026.8.2.\n\nRefs: ClawHub security scan for v2026.8.2