### PR TITLE
feat(monitor): context metadata + error placeholder cleanup (#211, #212)

### DIFF
--- a/src/zulip/monitor-helpers.ts
+++ b/src/zulip/monitor-helpers.ts
@@ -122,3 +122,46 @@ export function maskPII(value: string | number | undefined | null): string {
 export function delay(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
+
+/**
+ * Compute and track conversation metadata for inbound messages.
+ * Issue #211: conversation_turn, session_gap_seconds, topic_changed
+ */
+export function trackConversationMetadata(params: {
+  sessionKey: string;
+  channelId: string;
+  topic: string | undefined;
+  isDM: boolean;
+  now: number;
+  messageCounts: Map<string, number>;
+  lastMessageTimes: Map<string, number>;
+  lastTopicCache: Map<string, string>;
+}): {
+  conversationTurn: number;
+  sessionGapSeconds: number;
+  topicChanged: boolean;
+} {
+  const { sessionKey, channelId, topic, isDM, now, messageCounts, lastMessageTimes, lastTopicCache } = params;
+
+  const msgCount = (messageCounts.get(sessionKey) ?? 0) + 1;
+  messageCounts.set(sessionKey, msgCount);
+
+  const lastMsgTime = lastMessageTimes.get(sessionKey);
+  const sessionGap = lastMsgTime ? now - lastMsgTime : 0;
+  lastMessageTimes.set(sessionKey, now);
+
+  let topicChanged = false;
+  if (!isDM && topic) {
+    const prevTopic = lastTopicCache.get(channelId);
+    if (prevTopic !== undefined && prevTopic !== topic) {
+      topicChanged = true;
+    }
+    lastTopicCache.set(channelId, topic);
+  }
+
+  return {
+    conversationTurn: msgCount,
+    sessionGapSeconds: Math.round(sessionGap / 1000),
+    topicChanged,
+  };
+}

--- a/src/zulip/monitor.ts
+++ b/src/zulip/monitor.ts
@@ -6,6 +6,7 @@ import { resolveChannelMediaMaxBytes } from "openclaw/plugin-sdk/media-runtime";
 import { getZulipRuntime } from "../runtime.js";
 import {
   deleteZulipQueue,
+  editZulipMessage,
   registerZulipQueue,
   sendZulipTyping,
   updateZulipMessageFlag,
@@ -17,6 +18,7 @@ import {
   formatZulipLog,
   maskPII,
   delay,
+  trackConversationMetadata,
 } from "./monitor-helpers.js";
 import { ZulipDedupeStore } from "./dedupe-store.js";
 import { sendMessageZulip } from "./send.js";
@@ -117,6 +119,11 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
       maxSize: RECENT_MESSAGE_MAX,
     });
     await dedupeStore.load();
+
+    // Issue #211: Conversation metadata tracking (conversation_turn, session_gap_seconds, topic_changed)
+    const messageCounts = new Map<string, number>();
+    const lastMessageTimes = new Map<string, number>();
+    const lastTopicCache = new Map<string, string>();
 
     // Use full config from runtime instead of passed cfg to get channel settings
     // (fullCfg already loaded above at line ~90)
@@ -482,6 +489,18 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
       });
       const sessionKey = threadKeys.sessionKey;
 
+      // Issue #211: Compute conversation metadata (conversation_turn, session_gap_seconds, topic_changed)
+      const { conversationTurn, sessionGapSeconds, topicChanged } = trackConversationMetadata({
+        sessionKey,
+        channelId,
+        topic,
+        isDM,
+        now: Date.now(),
+        messageCounts,
+        lastMessageTimes,
+        lastTopicCache,
+      });
+
       const preview = bodyText.replace(/\s+/g, " ").slice(0, 160);
       const inboundLabel =
         kind === "dm"
@@ -556,6 +575,10 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
         MediaUrls: mediaUrls.length > 0 ? mediaUrls : undefined,
         MediaType: mediaTypes[0],
         MediaTypes: mediaTypes.length > 0 ? mediaTypes : undefined,
+        // Issue #211: Context metadata for agent
+        ConversationTurn: conversationTurn,
+        SessionGapSeconds: sessionGapSeconds,
+        TopicChanged: topicChanged,
       });
 
       if (kind === "dm") {
@@ -645,6 +668,17 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
             reactionsEnabled,
             logVerbose: logVerboseMessage,
           });
+          // Issue #212: Best-effort cleanup orphaned placeholder on dispatch error
+          if (placeholderMessageId) {
+            try {
+              await editZulipMessage(client, {
+                messageId: placeholderMessageId,
+                content: "❌ Error — could not generate response",
+              });
+            } catch (editErr) {
+              logVerboseMessage(`zulip placeholder error cleanup failed: ${String(editErr)}`);
+            }
+          }
           // UX: Best-effort send an explanatory reply when dispatch fails in channels
           if (!isDM) {
             try {

--- a/test/monitor-metadata.test.ts
+++ b/test/monitor-metadata.test.ts
@@ -1,0 +1,189 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { trackConversationMetadata } from "../src/zulip/monitor-helpers.js";
+
+const monitorPath = path.resolve(process.cwd(), "src/zulip/monitor.ts");
+
+// ── Unit tests for trackConversationMetadata ────────────────────────────────
+
+test("trackConversationMetadata: first message has turn 1, gap 0, no topic change", () => {
+  const messageCounts = new Map<string, number>();
+  const lastMessageTimes = new Map<string, number>();
+  const lastTopicCache = new Map<string, string>();
+
+  const result = trackConversationMetadata({
+    sessionKey: "sess:1",
+    channelId: "stream:42",
+    topic: "general",
+    isDM: false,
+    now: 1000,
+    messageCounts,
+    lastMessageTimes,
+    lastTopicCache,
+  });
+
+  assert.equal(result.conversationTurn, 1);
+  assert.equal(result.sessionGapSeconds, 0);
+  assert.equal(result.topicChanged, false);
+});
+
+test("trackConversationMetadata: second message increments turn and tracks gap", () => {
+  const messageCounts = new Map<string, number>();
+  const lastMessageTimes = new Map<string, number>();
+  const lastTopicCache = new Map<string, string>();
+
+  // First message
+  trackConversationMetadata({
+    sessionKey: "sess:1",
+    channelId: "stream:42",
+    topic: "general",
+    isDM: false,
+    now: 1000,
+    messageCounts,
+    lastMessageTimes,
+    lastTopicCache,
+  });
+
+  // Second message 5 seconds later
+  const result = trackConversationMetadata({
+    sessionKey: "sess:1",
+    channelId: "stream:42",
+    topic: "general",
+    isDM: false,
+    now: 6000,
+    messageCounts,
+    lastMessageTimes,
+    lastTopicCache,
+  });
+
+  assert.equal(result.conversationTurn, 2);
+  assert.equal(result.sessionGapSeconds, 5);
+  assert.equal(result.topicChanged, false);
+});
+
+test("trackConversationMetadata: detects topic change in streams", () => {
+  const messageCounts = new Map<string, number>();
+  const lastMessageTimes = new Map<string, number>();
+  const lastTopicCache = new Map<string, string>();
+
+  // First message in topic "general"
+  trackConversationMetadata({
+    sessionKey: "sess:1",
+    channelId: "stream:42",
+    topic: "general",
+    isDM: false,
+    now: 1000,
+    messageCounts,
+    lastMessageTimes,
+    lastTopicCache,
+  });
+
+  // Second message in topic "updates"
+  const result = trackConversationMetadata({
+    sessionKey: "sess:1",
+    channelId: "stream:42",
+    topic: "updates",
+    isDM: false,
+    now: 2000,
+    messageCounts,
+    lastMessageTimes,
+    lastTopicCache,
+  });
+
+  assert.equal(result.topicChanged, true);
+});
+
+test("trackConversationMetadata: separate sessions track independently", () => {
+  const messageCounts = new Map<string, number>();
+  const lastMessageTimes = new Map<string, number>();
+  const lastTopicCache = new Map<string, string>();
+
+  const r1 = trackConversationMetadata({
+    sessionKey: "sess:A",
+    channelId: "stream:1",
+    topic: "t1",
+    isDM: false,
+    now: 1000,
+    messageCounts,
+    lastMessageTimes,
+    lastTopicCache,
+  });
+
+  const r2 = trackConversationMetadata({
+    sessionKey: "sess:B",
+    channelId: "stream:2",
+    topic: "t2",
+    isDM: false,
+    now: 2000,
+    messageCounts,
+    lastMessageTimes,
+    lastTopicCache,
+  });
+
+  assert.equal(r1.conversationTurn, 1);
+  assert.equal(r2.conversationTurn, 1);
+});
+
+test("trackConversationMetadata: DMs do not track topic changes", () => {
+  const messageCounts = new Map<string, number>();
+  const lastMessageTimes = new Map<string, number>();
+  const lastTopicCache = new Map<string, string>();
+
+  const result = trackConversationMetadata({
+    sessionKey: "dm:alice",
+    channelId: "user:alice",
+    topic: undefined,
+    isDM: true,
+    now: 1000,
+    messageCounts,
+    lastMessageTimes,
+    lastTopicCache,
+  });
+
+  assert.equal(result.topicChanged, false);
+});
+
+test("trackConversationMetadata: first topic in stream does not count as changed", () => {
+  const messageCounts = new Map<string, number>();
+  const lastMessageTimes = new Map<string, number>();
+  const lastTopicCache = new Map<string, string>();
+
+  const result = trackConversationMetadata({
+    sessionKey: "sess:1",
+    channelId: "stream:42",
+    topic: "new-topic",
+    isDM: false,
+    now: 1000,
+    messageCounts,
+    lastMessageTimes,
+    lastTopicCache,
+  });
+
+  // First time seeing this stream — no previous topic to compare
+  assert.equal(result.topicChanged, false);
+  assert.equal(lastTopicCache.get("stream:42"), "new-topic");
+});
+
+// ── Source regression tests for monitor.ts ──────────────────────────────────
+
+test("monitor source: context metadata tracking variables are present", async () => {
+  const source = await fs.readFile(monitorPath, "utf8");
+  assert.equal(source.includes("messageCounts"), true);
+  assert.equal(source.includes("lastMessageTimes"), true);
+  assert.equal(source.includes("lastTopicCache"), true);
+});
+
+test("monitor source: context metadata fields are added to ctxPayload", async () => {
+  const source = await fs.readFile(monitorPath, "utf8");
+  assert.equal(source.includes("ConversationTurn"), true);
+  assert.equal(source.includes("SessionGapSeconds"), true);
+  assert.equal(source.includes("TopicChanged"), true);
+});
+
+test("monitor source: error placeholder cleanup is present", async () => {
+  const source = await fs.readFile(monitorPath, "utf8");
+  assert.equal(source.includes("editZulipMessage"), true);
+  assert.equal(source.includes("❌ Error — could not generate response"), true);
+});


### PR DESCRIPTION
## Summary

Closes #211 (context metadata) and #212 (error placeholder cleanup).

## Issue #211: Context Metadata for Agent

Adds three fields to every inbound Zulip message's `ctxPayload` to help the AI agent understand conversation continuity:

| Field | Type | Description |
|-------|------|-------------|
| `ConversationTurn` | `number` | Cumulative message count per session |
| `SessionGapSeconds` | `number` | Seconds since last message in same session |
| `TopicChanged` | `boolean` | Did the Zulip topic change since the last message? |

**Implementation:**
- New helper `trackConversationMetadata()` in `src/zulip/monitor-helpers.ts`
- Scoped `Map`s per account for `messageCounts`, `lastMessageTimes`, `lastTopicCache`
- Enriched `ctxPayload` in `src/zulip/monitor.ts`

**Reference:** Hermes `zulip/adapter.py` does equivalent tracking.

## Issue #212: Error Placeholder Cleanup

When `dispatchZulipReply` fails, the orphaned "🤔 Thinking..." placeholder is now edited to:

```
❌ Error — could not generate response
```

**Implementation:**
- Added `editZulipMessage` import from `./client.js`
- Best-effort cleanup inside the existing `if (dispatchError)` block
- Catches its own errors so a failed edit never breaks the flow

**Reference:** Hermes `zulip/adapter.py` has equivalent error cleanup.

## Tests

- **6 unit tests** for `trackConversationMetadata()` covering turn counting, gap tracking, topic change detection, session isolation, DM behavior, and first-topic edge case
- **3 source regression tests** verifying `monitor.ts` contains expected patterns
- **Total:** +9 tests, 125 tests overall (124 pass, 1 skipped)

## Files Changed

- `src/zulip/monitor.ts` — state tracking, metadata enrichment, error cleanup
- `src/zulip/monitor-helpers.ts` — `trackConversationMetadata()` helper
- `test/monitor-metadata.test.ts` — new test file (9 tests)
