### PR TITLE
perf(zulip): reduce message latency (#216)

### DIFF
--- a/src/zulip/monitor.ts
+++ b/src/zulip/monitor.ts
@@ -8,7 +8,6 @@ import {
   deleteZulipQueue,
   editZulipMessage,
   registerZulipQueue,
-  sendZulipTyping,
   updateZulipMessageFlag,
   type ZulipMessage,
 } from "./client.js";
@@ -432,20 +431,6 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
         messageId,
       });
 
-      // UX: Start typing indicators immediately so users see activity during long generations
-      if (!isDM && streamId) {
-        try {
-          await sendZulipTyping(client, {
-            op: "start",
-            type: "stream",
-            streamId: Number(streamId),
-            topic: topic || DEFAULT_TOPIC,
-          });
-        } catch {
-          // best-effort typing indicator
-        }
-      }
-
       const effectiveWasMentioned =
         wasMentioned || (isControlCommand && commandAuthorized) || oncharTriggered;
 
@@ -526,23 +511,28 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
 
       // UX: Send a "Thinking..." placeholder message immediately so users see activity.
       // We will edit this message in-place with the actual response when ready.
+      // Best-effort: don't block the dispatch on this network call.
       let placeholderMessageId: string | undefined;
-      try {
-        const phResult = await sendMessageZulip(to, "🤔 Thinking...", {
-          accountId: account.accountId,
-          topic,
-        });
-        if (phResult?.messageId) {
-          placeholderMessageId = phResult.messageId;
-        }
-      } catch (err) {
-        core.log?.(
-          formatZulipLog("zulip placeholder send failed", {
+      const placeholderPromise = (async (): Promise<string | undefined> => {
+        try {
+          const phResult = await sendMessageZulip(to, "🤔 Thinking...", {
             accountId: account.accountId,
-            error: String(err),
-          }),
-        );
-      }
+            topic,
+          });
+          if (phResult?.messageId) {
+            placeholderMessageId = phResult.messageId;
+          }
+          return placeholderMessageId;
+        } catch (err) {
+          core.log?.(
+            formatZulipLog("zulip placeholder send failed", {
+              accountId: account.accountId,
+              error: String(err),
+            }),
+          );
+          return undefined;
+        }
+      })();
 
       const ctxPayload = core.channel.reply.finalizeInboundContext({
         Body: body,
@@ -647,12 +637,12 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
         to,
         statusSink: opts.statusSink,
         logVerboseMessage,
-        placeholderMessageId,
+        placeholderMessageIdPromise: placeholderPromise,
       });
 
       if (reactionsEnabled) {
         if (reactionClearOnFinish) {
-          await removeReactionSafe({
+          void removeReactionSafe({
             client,
             messageId,
             emojiName: reactionStart,
@@ -661,7 +651,7 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
           });
         }
         if (dispatchError) {
-          await addReactionSafe({
+          void addReactionSafe({
             client,
             messageId,
             emojiName: reactionError,
@@ -669,33 +659,34 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
             logVerbose: logVerboseMessage,
           });
           // Issue #212: Best-effort cleanup orphaned placeholder on dispatch error
-          if (placeholderMessageId) {
-            try {
-              await editZulipMessage(client, {
-                messageId: placeholderMessageId,
-                content: "❌ Error — could not generate response",
-              });
-            } catch (editErr) {
-              logVerboseMessage(`zulip placeholder error cleanup failed: ${String(editErr)}`);
-            }
+          if (placeholderPromise) {
+            void (async () => {
+              const phId = placeholderMessageId ?? (await placeholderPromise.catch(() => undefined));
+              if (phId) {
+                try {
+                  await editZulipMessage(client, {
+                    messageId: phId,
+                    content: "❌ Error — could not generate response",
+                  });
+                } catch (editErr) {
+                  logVerboseMessage(`zulip placeholder error cleanup failed: ${String(editErr)}`);
+                }
+              }
+            })();
           }
           // UX: Best-effort send an explanatory reply when dispatch fails in channels
           if (!isDM) {
-            try {
-              await sendMessageZulip(
-                to,
-                "⚠️ I encountered an error processing this message. Please try again.",
-                {
-                  accountId: account.accountId,
-                  topic,
-                },
-              );
-            } catch {
-              // best-effort
-            }
+            void sendMessageZulip(
+              to,
+              "⚠️ I encountered an error processing this message. Please try again.",
+              {
+                accountId: account.accountId,
+                topic,
+              },
+            ).catch(() => undefined);
           }
         } else {
-          await addReactionSafe({
+          void addReactionSafe({
             client,
             messageId,
             emojiName: reactionSuccess,
@@ -705,16 +696,14 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
         }
       }
 
-      // Mark processed message as read (best-effort)
-      try {
-        await updateZulipMessageFlag(client, {
-          messageId,
-          flag: "read",
-          op: "add",
-        });
-      } catch (err) {
+      // Mark processed message as read (best-effort, don't block inbound completion)
+      void updateZulipMessageFlag(client, {
+        messageId,
+        flag: "read",
+        op: "add",
+      }).catch((err) => {
         logVerboseMessage(`zulip mark-read failed: ${String(err)}`);
-      }
+      });
 
       opts.statusSink?.({ lastInboundAt: Date.now() });
     };

--- a/src/zulip/reply-handler.ts
+++ b/src/zulip/reply-handler.ts
@@ -32,7 +32,7 @@ export async function dispatchZulipReply(params: {
   to: string;
   statusSink?: (patch: any) => void;
   logVerboseMessage: (msg: string) => void;
-  placeholderMessageId?: string;
+  placeholderMessageIdPromise?: Promise<string | undefined>;
 }): Promise<unknown> {
   const {
     core,
@@ -54,7 +54,7 @@ export async function dispatchZulipReply(params: {
     to,
     statusSink,
     logVerboseMessage,
-    placeholderMessageId,
+    placeholderMessageIdPromise,
   } = params;
 
   const typingParams = isDM
@@ -93,6 +93,7 @@ export async function dispatchZulipReply(params: {
   });
 
   let deliveredAny = false;
+  let placeholderMessageId: string | undefined;
   let placeholderConsumed = false;
 
   const { dispatcher, replyOptions, markDispatchIdle } =
@@ -102,6 +103,18 @@ export async function dispatchZulipReply(params: {
       onReplyStart: typingCallbacks.onReplyStart,
       deliver: async (payload: ReplyPayload) => {
         deliveredAny = true;
+        if (!placeholderConsumed) {
+          placeholderConsumed = true;
+          if (placeholderMessageIdPromise) {
+            try {
+              placeholderMessageId = await placeholderMessageIdPromise;
+            } catch (err) {
+              logVerboseMessage(
+                `zulip placeholder promise rejected: ${String(err)}; falling back to new message`,
+              );
+            }
+          }
+        }
         const mediaUrls = payload.mediaUrls ?? (payload.mediaUrl ? [payload.mediaUrl] : []);
         const rawText = core.channel.text.convertMarkdownTables(payload.text ?? "", tableMode);
         const { text, topic: topicOverride } = extractZulipTopicDirective(rawText);
@@ -113,8 +126,7 @@ export async function dispatchZulipReply(params: {
           for (let idx = 0; idx < nonEmptyChunks.length; idx++) {
             const chunk = nonEmptyChunks[idx];
             // UX: Edit the placeholder message for the first chunk, then send new messages for the rest.
-            if (!placeholderConsumed && placeholderMessageId) {
-              placeholderConsumed = true;
+            if (placeholderMessageId) {
               try {
                 await editZulipMessage(client, {
                   messageId: placeholderMessageId,
@@ -141,8 +153,7 @@ export async function dispatchZulipReply(params: {
           for (const mediaUrl of mediaUrls) {
             const caption = first ? text : "";
             first = false;
-            if (!placeholderConsumed && placeholderMessageId) {
-              placeholderConsumed = true;
+            if (placeholderMessageId) {
               try {
                 await editZulipMessage(client, {
                   messageId: placeholderMessageId,


### PR DESCRIPTION
## Problem
Zulip messages are consistently 10-30s slower than Telegram despite using the same model. Profiling inside the container shows Zulip API round-trips take ~600ms each and the plugin makes several sequential blocking calls per message.

## Findings
- `GET /users/me`, `POST /typing`, `POST /messages` each take ~600ms from the container.
- A single Zulip DM currently performs up to 9 sequential Zulip API calls (typing, placeholder, reactions, mark-read, edit, etc.).
- Stream messages have a duplicate typing indicator: `monitor.ts` sends one before dispatch, then `reply-handler.ts` sends another via typing callbacks.
- Reactions and mark-read are awaited in the hot path.
- The placeholder is awaited before dispatch starts, adding ~600ms before the model can even begin.

## Proposed Fixes
1. Remove the duplicate stream typing indicator from `monitor.ts` (reply-handler already handles it).
2. Make placeholder send best-effort and non-blocking: start it immediately, but only wait for its ID inside the first deliver callback when the actual response is ready.
3. Make reactions and mark-read fire-and-forget so they do not block inbound completion.

## Files
- `src/zulip/monitor.ts`
- `src/zulip/reply-handler.ts`

## Acceptance Criteria
- Full `npm run check` passes.
- Existing 125 tests still pass (124 pass / 1 skipped).
- Manual container test shows reduced message latency.
