### PR TITLE
feat(zulip): make thinking placeholder configurable (#218)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -124,5 +124,6 @@ Migration complete as of v2026.7.0:
 - **No startup logs** for your channel? Verify host calls `startAccount` and `listAccountIds` returns expected account IDs.
 - **Telegram fetch timeouts**: Separate network issue on the test device, not related to your plugin.
 - **Bot presence not showing online**: Zulip API rejects `POST /users/me/presence` for bot accounts. This is a platform limitation, not a bug.
+- **Zulip responses are slower than Telegram**: Zulip API round-trips from the container take ~600ms each. To reduce latency, keep `showThinkingPlaceholder: false` (default) so the bot only shows a typing indicator instead of posting and editing a "Thinking..." placeholder message. Enable the placeholder only when users need the extra visual feedback.
 
 **Note**: This file is maintained as project documentation and is safe to commit.

--- a/README.md
+++ b/README.md
@@ -246,6 +246,7 @@ For advanced users, add to your `openclaw.json`:
 | `reactions` | boolean | `true` | Enable reaction-based status indicators |
 | `streaming` | boolean | `true` | Enable receiving streaming messages |
 | `responsePrefix` | string | - | Custom response prefix override |
+| `showThinkingPlaceholder` | boolean | `false` | Post a "🤔 Thinking..." placeholder while generating. Disabled by default because it adds a Zulip API round-trip; typing indicators are shown either way. |
 
 #### Environment Variables
 

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -111,6 +111,7 @@
           "responsePrefix": { "type": "string" },
           "enableAdminActions": { "type": "boolean" },
           "autoSendOnMissingTool": { "type": "boolean" },
+          "showThinkingPlaceholder": { "type": "boolean" },
           "accounts": {
             "type": "object",
             "additionalProperties": true
@@ -202,6 +203,7 @@
           "responsePrefix": { "type": "string" },
           "enableAdminActions": { "type": "boolean" },
           "autoSendOnMissingTool": { "type": "boolean" },
+          "showThinkingPlaceholder": { "type": "boolean" },
           "accounts": {
             "type": "object",
             "additionalProperties": true
@@ -285,6 +287,10 @@
         "autoSendOnMissingTool": {
           "label": "Auto-send on missing tool call",
           "description": "If the agent ends a run with assistant text but never invoked the messaging tool, deliver the text to the channel anyway. Default: true."
+        },
+        "showThinkingPlaceholder": {
+          "label": "Show thinking placeholder",
+          "description": "Post a \"Thinking...\" placeholder message while generating a response. Disabled by default because it adds one Zulip API round-trip; typing indicators are shown either way."
         }
       }
     }

--- a/src/config-schema.ts
+++ b/src/config-schema.ts
@@ -47,6 +47,7 @@ const ZulipAccountSchema = z.object({
   responsePrefix: z.string().optional(),
   enableAdminActions: z.boolean().default(false),
   autoSendOnMissingTool: z.boolean().optional(),
+  showThinkingPlaceholder: z.boolean().optional(),
 });
 
 const ZulipConfigSchema = buildCatchallMultiAccountChannelSchema(

--- a/src/config-ui-hints.ts
+++ b/src/config-ui-hints.ts
@@ -65,4 +65,8 @@ export const zulipChannelConfigUiHints = {
     label: "Zulip Response Prefix",
     help: "Optional prefix added before outbound Zulip responses.",
   },
+  showThinkingPlaceholder: {
+    label: "Show thinking placeholder",
+    help: "Post a \"Thinking...\" placeholder message while generating a response. Disabled by default because it adds one Zulip API round-trip; typing indicators are shown either way.",
+  },
 } satisfies Record<string, ZulipChannelConfigUiHint>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -76,6 +76,16 @@ export type ZulipAccountConfig = {
    * Default: true. Set to false to enforce strict tool-call semantics.
    */
   autoSendOnMissingTool?: boolean;
+  /**
+   * Show a "Thinking..." placeholder message while the model is generating
+   * a response. When true the bot posts a message that is edited in-place
+   * once the response is ready; when false it only shows a typing indicator.
+   * Disabling the placeholder reduces Zulip API overhead and improves
+   * response latency.
+   *
+   * Default: false.
+   */
+  showThinkingPlaceholder?: boolean;
 };
 
 export type ZulipConfig = {

--- a/src/zulip/accounts.ts
+++ b/src/zulip/accounts.ts
@@ -29,6 +29,7 @@ export type ResolvedZulipAccount = {
   streaming?: boolean;
   streams?: string[];
   autoSendOnMissingTool?: boolean;
+  showThinkingPlaceholder?: boolean;
 };
 
 function resolveZulipSection(cfg: OpenClawConfig): ZulipConfig | undefined {
@@ -177,6 +178,7 @@ export function resolveZulipAccount(params: {
     streaming: merged.streaming,
     streams: merged.streams,
     autoSendOnMissingTool: merged.autoSendOnMissingTool,
+    showThinkingPlaceholder: merged.showThinkingPlaceholder,
   };
 }
 

--- a/src/zulip/monitor.ts
+++ b/src/zulip/monitor.ts
@@ -509,30 +509,33 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
 
       const to = kind === "dm" ? `user:${senderId}` : `stream:${streamName || streamId}:${topic}`;
 
-      // UX: Send a "Thinking..." placeholder message immediately so users see activity.
-      // We will edit this message in-place with the actual response when ready.
-      // Best-effort: don't block the dispatch on this network call.
+      // UX: Optionally send a "Thinking..." placeholder message immediately so users see activity.
+      // If disabled (default), we rely on typing indicators only, which avoids one Zulip API round-trip.
+      // When enabled, the placeholder is edited in-place once the actual response is ready.
       let placeholderMessageId: string | undefined;
-      const placeholderPromise = (async (): Promise<string | undefined> => {
-        try {
-          const phResult = await sendMessageZulip(to, "🤔 Thinking...", {
-            accountId: account.accountId,
-            topic,
-          });
-          if (phResult?.messageId) {
-            placeholderMessageId = phResult.messageId;
-          }
-          return placeholderMessageId;
-        } catch (err) {
-          core.log?.(
-            formatZulipLog("zulip placeholder send failed", {
-              accountId: account.accountId,
-              error: String(err),
-            }),
-          );
-          return undefined;
-        }
-      })();
+      const usePlaceholder = account.showThinkingPlaceholder === true;
+      const placeholderPromise = usePlaceholder
+        ? (async (): Promise<string | undefined> => {
+            try {
+              const phResult = await sendMessageZulip(to, "🤔 Thinking...", {
+                accountId: account.accountId,
+                topic,
+              });
+              if (phResult?.messageId) {
+                placeholderMessageId = phResult.messageId;
+              }
+              return placeholderMessageId;
+            } catch (err) {
+              core.log?.(
+                formatZulipLog("zulip placeholder send failed", {
+                  accountId: account.accountId,
+                  error: String(err),
+                }),
+              );
+              return undefined;
+            }
+          })()
+        : Promise.resolve(undefined);
 
       const ctxPayload = core.channel.reply.finalizeInboundContext({
         Body: body,

--- a/test/monitor-metadata.test.ts
+++ b/test/monitor-metadata.test.ts
@@ -187,3 +187,9 @@ test("monitor source: error placeholder cleanup is present", async () => {
   assert.equal(source.includes("editZulipMessage"), true);
   assert.equal(source.includes("❌ Error — could not generate response"), true);
 });
+
+test("monitor source: showThinkingPlaceholder is configurable and defaults off", async () => {
+  const source = await fs.readFile(monitorPath, "utf8");
+  assert.equal(source.includes("showThinkingPlaceholder"), true);
+  assert.equal(source.includes("Promise.resolve(undefined)"), true);
+});


### PR DESCRIPTION
## Context
Issue #216 reduced Zulip latency by making reactions/mark-read fire-and-forget and the placeholder send non-blocking. This follow-up makes the placeholder itself optional so the default behavior avoids the Zulip API round-trip entirely.

## Change

- Add `showThinkingPlaceholder` boolean config option to `ZulipAccountConfig`.
- Default is `false`: the bot shows only the typing indicator while generating a response.
- When explicitly set to `true`, the bot posts a "🤔 Thinking..." placeholder and edits it in-place once the response is ready.

## Files touched

- `src/types.ts`
- `src/config-schema.ts`
- `src/config-ui-hints.ts`
- `src/zulip/accounts.ts`
- `src/zulip/monitor.ts`
- `openclaw.plugin.json`
- `README.md`
- `AGENTS.md`
- `test/monitor-metadata.test.ts`

## Acceptance criteria

- Full `npm run check` passes.
- 126 tests: 125 pass, 1 skip, 0 fail.
- README and AGENTS document the new option and the latency trade-off.

Relates to #216.
Closes #218..
