### PR TITLE
fix(polling): don't block Zulip poll loop on slow message handlers (#220)

### DIFF
--- a/src/zulip/polling.ts
+++ b/src/zulip/polling.ts
@@ -91,16 +91,31 @@ export async function pollOnce(params: {
     let maxEventId = -1;
 
     try {
+      const processing: Promise<void>[] = [];
       for (const event of events) {
         if (event.type === "message" && event.message) {
-          
-          await processMessage(event.message);
+          // Process messages asynchronously so a slow model call does not block
+          // the poll loop. The host's session locks still serialize messages
+          // for the same session, while unrelated sessions can run in parallel.
+          processing.push(
+            processMessage(event.message).catch((err) => {
+              core.error?.(
+                formatZulipLog("zulip message processing error", {
+                  accountId,
+                  error: String(err),
+                }),
+              );
+            }),
+          );
         }
         const nextEventId = Number((event as { id?: unknown })?.id);
         if (!Number.isNaN(nextEventId) && nextEventId > maxEventId) {
           maxEventId = nextEventId;
         }
       }
+      // Intentionally do NOT await processing here. The poll loop must keep
+      // fetching events; processMessage handles its own errors and retries.
+      void Promise.all(processing);
     } finally {
       if (maxEventId > 0) {
         // ⚡ Bolt Optimization: Batch disk I/O updates for event ID


### PR DESCRIPTION
## Problem

When a Zulip message triggers a slow model call or timeout, the entire Zulip channel appears frozen. Subsequent Zulip messages are not received or replied to until the slow run (including retries) finally completes or times out.

Telegram does not exhibit this behavior: messages keep flowing even when some model calls are slow.

## Root Cause

In `src/zulip/polling.ts`, the poll loop awaited each `processMessage` call before continuing:

```typescript
for (const event of events) {
  if (event.type === "message" && event.message) {
    await processMessage(event.message);  // blocks poll loop for 60s+
  }
}
```

Zulip event queues hold events until acknowledged. While the loop was blocked, no new events were fetched and no new messages could be processed.

## Evidence

Session trajectory `5e11f3b4-35de-411c-acc3-0fc0b45e3905.jsonl` shows the Zulip message `so how fast you can go?` received at 21:23:34. The model call timed out at 21:24:34, retried, and timed out again at 21:25:40. During that ~2 minute window, no other Zulip events were polled. A Telegram message sent during the same window was handled immediately.

## Fix

Process Zulip messages asynchronously so the poll loop can continue fetching events. The OpenClaw host's per-session locks still serialize messages within a session, preserving ordering. Errors are caught and logged by the existing `processMessage` wrapper.

## Files

- `src/zulip/polling.ts`

## Acceptance Criteria

- Full `npm run check` passes.
- Existing 126 tests pass (125 pass, 1 skip).
- Zulip channel remains responsive when individual messages hit slow model calls.
