### PR TITLE
fix(zulip): DM session rotation, faster reactions/typing, chat profile docs (#222 #224 #225)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -125,5 +125,6 @@ Migration complete as of v2026.7.0:
 - **Telegram fetch timeouts**: Separate network issue on the test device, not related to your plugin.
 - **Bot presence not showing online**: Zulip API rejects `POST /users/me/presence` for bot accounts. This is a platform limitation, not a bug.
 - **Zulip responses are slower than Telegram**: Zulip API round-trips from the container take ~600ms each. To reduce latency, keep `showThinkingPlaceholder: false` (default) so the bot only shows a typing indicator instead of posting and editing a "Thinking..." placeholder message. Enable the placeholder only when users need the extra visual feedback.
+- **`message` tool removed by host `coding` profile**: The host's `tools.profile: "coding"` strips the `message` tool from the agent, so replies fall back to reading the session trajectory after the run ends. For the cleanest chat UX, use a profile that keeps `message` (e.g., `"chat"`) or add `message` to the profile's allowlist. This affects all chat channels, not just Zulip.
 
 **Note**: This file is maintained as project documentation and is safe to commit.

--- a/README.md
+++ b/README.md
@@ -247,6 +247,7 @@ For advanced users, add to your `openclaw.json`:
 | `streaming` | boolean | `true` | Enable receiving streaming messages |
 | `responsePrefix` | string | - | Custom response prefix override |
 | `showThinkingPlaceholder` | boolean | `false` | Post a "🤔 Thinking..." placeholder while generating. Disabled by default because it adds a Zulip API round-trip; typing indicators are shown either way. |
+| `dmSessionTurnLimit` | number | `20` | Maximum inbound DM conversation turns before starting a fresh session. Prevents one long/broken conversation from bloating context for all future replies in the same DM. Set to `0` to disable rotation. |
 
 #### Environment Variables
 
@@ -376,6 +377,12 @@ Default requires @mentions. Check your `chatmode` setting.
 
 ### Typing indicator TTL exceeded
 The typing indicator auto-stops after 60 seconds if the response takes longer. This is expected behavior.
+
+### Replies are sent via fallback instead of the `message` tool
+The host's `tools.profile: "coding"` removes the `message` tool from the agent. The plugin still delivers replies through its `autoSendOnMissingTool` fallback, but for the cleanest chat UX use a profile that keeps `message` (e.g., `"chat"`) or add `message` to the profile allowlist. This affects all chat channels, not just Zulip.
+
+### Zulip responses are slower than Telegram
+Zulip API round-trips from the container take ~600ms each. To reduce latency, keep `showThinkingPlaceholder: false` (default) and avoid enabling the placeholder unless users need the extra visual feedback.
 
 ---
 

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -112,6 +112,10 @@
           "enableAdminActions": { "type": "boolean" },
           "autoSendOnMissingTool": { "type": "boolean" },
           "showThinkingPlaceholder": { "type": "boolean" },
+          "dmSessionTurnLimit": {
+            "type": "integer",
+            "minimum": 0
+          },
           "accounts": {
             "type": "object",
             "additionalProperties": true
@@ -291,6 +295,10 @@
         "showThinkingPlaceholder": {
           "label": "Show thinking placeholder",
           "description": "Post a \"Thinking...\" placeholder message while generating a response. Disabled by default because it adds one Zulip API round-trip; typing indicators are shown either way."
+        },
+        "dmSessionTurnLimit": {
+          "label": "DM session turn limit",
+          "description": "Maximum inbound conversation turns in a single Zulip DM session before starting a fresh session. Prevents one long/broken conversation from bloating context for all future replies. 0 disables rotation."
         }
       }
     }

--- a/src/config-schema.ts
+++ b/src/config-schema.ts
@@ -48,6 +48,7 @@ const ZulipAccountSchema = z.object({
   enableAdminActions: z.boolean().default(false),
   autoSendOnMissingTool: z.boolean().optional(),
   showThinkingPlaceholder: z.boolean().optional(),
+  dmSessionTurnLimit: z.number().int().min(0).optional(),
 });
 
 const ZulipConfigSchema = buildCatchallMultiAccountChannelSchema(

--- a/src/config-ui-hints.ts
+++ b/src/config-ui-hints.ts
@@ -69,4 +69,8 @@ export const zulipChannelConfigUiHints = {
     label: "Show thinking placeholder",
     help: "Post a \"Thinking...\" placeholder message while generating a response. Disabled by default because it adds one Zulip API round-trip; typing indicators are shown either way.",
   },
+  dmSessionTurnLimit: {
+    label: "DM session turn limit",
+    help: "Maximum inbound conversation turns in a single Zulip DM session before starting a fresh session. Prevents one long/broken conversation from bloating context for all future replies. 0 disables rotation.",
+  },
 } satisfies Record<string, ZulipChannelConfigUiHint>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -86,6 +86,17 @@ export type ZulipAccountConfig = {
    * Default: false.
    */
   showThinkingPlaceholder?: boolean;
+  /**
+   * Maximum number of inbound conversation turns in a single Zulip DM session
+   * before starting a fresh session key. Rotating DM sessions prevents a single
+   * long-running or broken conversation from accumulating unbounded context
+   * that slows every future reply. Stream/topic sessions are not rotated.
+   *
+   * Use `0` or `undefined` to disable rotation.
+   *
+   * Default: 20.
+   */
+  dmSessionTurnLimit?: number;
 };
 
 export type ZulipConfig = {

--- a/src/zulip/accounts.ts
+++ b/src/zulip/accounts.ts
@@ -30,6 +30,7 @@ export type ResolvedZulipAccount = {
   streams?: string[];
   autoSendOnMissingTool?: boolean;
   showThinkingPlaceholder?: boolean;
+  dmSessionTurnLimit?: number;
 };
 
 function resolveZulipSection(cfg: OpenClawConfig): ZulipConfig | undefined {
@@ -179,6 +180,7 @@ export function resolveZulipAccount(params: {
     streams: merged.streams,
     autoSendOnMissingTool: merged.autoSendOnMissingTool,
     showThinkingPlaceholder: merged.showThinkingPlaceholder,
+    dmSessionTurnLimit: merged.dmSessionTurnLimit,
   };
 }
 

--- a/src/zulip/monitor.ts
+++ b/src/zulip/monitor.ts
@@ -123,6 +123,9 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
     const messageCounts = new Map<string, number>();
     const lastMessageTimes = new Map<string, number>();
     const lastTopicCache = new Map<string, string>();
+    // Issue #222: Track inbound DM message counts against the unrotated base
+    // session key so we can rotate DM sessions before context bloat accumulates.
+    const dmBaseMessageCounts = new Map<string, number>();
 
     // Use full config from runtime instead of passed cfg to get channel settings
     // (fullCfg already loaded above at line ~90)
@@ -467,7 +470,22 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
         },
       });
 
-      const baseSessionKey = route.sessionKey ?? `zulip:${account.accountId}:${channelId}`;
+      // Issue #222: Rotate Zulip DM session keys after a configured number of
+      // inbound turns so one long/broken conversation cannot bloat context for
+      // every future message in the same DM. Streams and topics keep stable keys.
+      let baseSessionKey = route.sessionKey ?? `zulip:${account.accountId}:${channelId}`;
+      if (isDM) {
+        const turnLimit = account.dmSessionTurnLimit ?? 20;
+        if (turnLimit > 0) {
+          const dmTurnCount = (dmBaseMessageCounts.get(baseSessionKey) ?? 0) + 1;
+          dmBaseMessageCounts.set(baseSessionKey, dmTurnCount);
+          const epoch = Math.floor((dmTurnCount - 1) / turnLimit);
+          if (epoch > 0) {
+            baseSessionKey = `${baseSessionKey}:session:${epoch}`;
+          }
+        }
+      }
+
       const threadKeys = resolveThreadSessionKeys({
         baseSessionKey,
         threadId: topic !== DEFAULT_TOPIC ? topic : undefined,
@@ -604,7 +622,9 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
         }),
       );
 
-      await addReactionSafe({
+      // Issue #224: Start reaction is best-effort; don't block model inference
+      // on the Zulip API round-trip.
+      void addReactionSafe({
         client,
         messageId,
         emojiName: reactionStart,

--- a/src/zulip/reply-handler.ts
+++ b/src/zulip/reply-handler.ts
@@ -95,6 +95,7 @@ export async function dispatchZulipReply(params: {
   let deliveredAny = false;
   let placeholderMessageId: string | undefined;
   let placeholderConsumed = false;
+  let typingStopped = false;
 
   const { dispatcher, replyOptions, markDispatchIdle } =
     core.channel.reply.createReplyDispatcherWithTyping({
@@ -103,6 +104,13 @@ export async function dispatchZulipReply(params: {
       onReplyStart: typingCallbacks.onReplyStart,
       deliver: async (payload: ReplyPayload) => {
         deliveredAny = true;
+        // Issue #224: Stop the typing indicator as soon as the first chunk is
+        // delivered so the user does not see "bot is typing" after the reply
+        // is already visible. This is best-effort and idempotent.
+        if (!typingStopped) {
+          typingStopped = true;
+          void typingCallbacks.onIdle().catch(() => undefined);
+        }
         if (!placeholderConsumed) {
           placeholderConsumed = true;
           if (placeholderMessageIdPromise) {
@@ -182,6 +190,11 @@ export async function dispatchZulipReply(params: {
       },
       onError: (err: unknown) => {
         core.error?.(`zulip reply failed: ${String(err)}`);
+        // Issue #224: Ensure typing indicator stops promptly on dispatch error.
+        if (!typingStopped) {
+          typingStopped = true;
+          void typingCallbacks.onIdle().catch(() => undefined);
+        }
       },
     });
 

--- a/test/monitor-metadata.test.ts
+++ b/test/monitor-metadata.test.ts
@@ -193,3 +193,26 @@ test("monitor source: showThinkingPlaceholder is configurable and defaults off",
   assert.equal(source.includes("showThinkingPlaceholder"), true);
   assert.equal(source.includes("Promise.resolve(undefined)"), true);
 });
+
+test("monitor source: DM session rotation is present", async () => {
+  const source = await fs.readFile(monitorPath, "utf8");
+  assert.equal(source.includes("dmSessionTurnLimit"), true);
+  assert.equal(source.includes("dmBaseMessageCounts"), true);
+  assert.equal(source.includes(":session:"), true);
+});
+
+test("reply-handler source: typing indicator stops on first chunk delivery", async () => {
+  const source = await fs.readFile(
+    path.resolve(process.cwd(), "src/zulip/reply-handler.ts"),
+    "utf8",
+  );
+  assert.equal(source.includes("typingStopped"), true);
+  assert.equal(source.includes("typingCallbacks.onIdle"), true);
+  assert.equal(source.includes("onError: (err: unknown)"), true);
+});
+
+test("monitor source: start reaction is fire-and-forget", async () => {
+  const source = await fs.readFile(monitorPath, "utf8");
+  assert.equal(source.includes("Issue #224"), true);
+  assert.equal(source.includes("void addReactionSafe({"), true);
+});


### PR DESCRIPTION
## Summary
Closes #222, closes #224, closes #225.

Combines three small, related Zulip UX improvements:

1. **#222 — DM session rotation**: prevents a single long/broken Zulip DM conversation from accumulating unbounded context and slowing every future reply in that DM.
2. **#224 — Reaction/typing micro-optimizations**: makes the eyes reaction appear without blocking model inference, and stops the typing indicator as soon as the first reply chunk is visible.
3. **#225 — Chat profile documentation**: documents the host `tools.profile: "coding"` side effect that removes the `message` tool and the recommended workarounds.

## Changes
- Added `dmSessionTurnLimit` config option (integer ≥ 0; default `20`; `0` disables). After N inbound DM turns the session key rotates to a fresh `:session:{epoch}` suffix.
- Made the **start reaction** (`eyes`) fire-and-forget so it does not block model inference on the Zulip API round-trip.
- Stop the **typing indicator** immediately when the first reply chunk is delivered or when dispatch errors, instead of waiting for full dispatcher idle.
- Updated `README.md` and `AGENTS.md` with notes on `dmSessionTurnLimit`, the `coding` tool profile, and the `message` tool fallback.
- Added source regression tests for rotation, reaction, and typing changes.

## Validation
- `npm run check` passes: 129 tests, 128 pass, 1 skip, 0 failures.
- Smoke test passes on built `dist/` artifacts.
- Package validation passed.
- Branch already deployed and briefly tested in `lab-openclaw`; will do final container validation after merge.

## Note
ClawHub publish is intentionally deferred per project conventions; this PR is GitHub-only.
