### PR TITLE
fix(build): retry wrapper for ERR_REQUIRE_ESM_RACE_CONDITION on CJS openclaw/* requires (#231)

### DIFF
--- a/scripts/build-cjs.js
+++ b/scripts/build-cjs.js
@@ -13,34 +13,79 @@
  */
 import { build } from "esbuild";
 import { mkdir } from "node:fs/promises";
+import { readFileSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 
 const root = dirname(dirname(new URL(import.meta.url).pathname));
 const outdir = join(root, "dist-cjs");
 
+/**
+ * Injects a synchronous retry wrapper around require() calls to openclaw/* modules.
+ *
+ * Node.js 22.18+ / 24.x can throw ERR_REQUIRE_ESM_RACE_CONDITION when require()
+ * and import() resolve the same ESM module concurrently. The race is transient:
+ * the module is "not yet fully loaded" for only a few milliseconds. A bounded
+ * synchronous retry with a short spin-loop allows the concurrent loader to finish.
+ *
+ * This is intentionally limited to openclaw/* modules to avoid affecting any other
+ * dependencies. It is a workaround for nodejs/node#62432 and should be removed
+ * once upstream resolves the race.
+ *
+ * See: https://github.com/niyazmft/openclaw-zulip-bridge/issues/231
+ */
+function injectRequireRetryWrapper(cjsSource) {
+  const retryHelper = `function __requireWithRetry(id) {
+  if (typeof require === "undefined") throw new Error('Dynamic require of "' + id + '" is not supported');
+  if (typeof id !== "string" || !id.startsWith("openclaw/")) return require(id);
+  const MAX_RETRIES = 5;
+  const DELAY_MS = 20;
+  for (let i = 0; i < MAX_RETRIES; i++) {
+    try {
+      return require(id);
+    } catch (err) {
+      if (err && err.code === "ERR_REQUIRE_ESM_RACE_CONDITION" && i < MAX_RETRIES - 1) {
+        const start = Date.now();
+        while (Date.now() - start < DELAY_MS) {}
+        continue;
+      }
+      throw err;
+    }
+  }
+}
+`;
+  // Replace all require("openclaw/...") with __requireWithRetry("openclaw/...")
+  const patched = cjsSource.replace(
+    /require\("openclaw\//g,
+    '__requireWithRetry("openclaw/'
+  );
+  // Prepend the helper so it is available before any module code runs
+  return retryHelper + patched;
+}
+
+async function buildCjs(entry, out) {
+  await build({
+    bundle: true,
+    platform: "node",
+    target: "node18",
+    format: "cjs",
+    external: ["openclaw/*"],
+    sourcemap: true,
+    logLevel: "info",
+    entryPoints: [entry],
+    outfile: out,
+  });
+
+  const raw = readFileSync(out, "utf-8");
+  const wrapped = injectRequireRetryWrapper(raw);
+  writeFileSync(out, wrapped, "utf-8");
+  console.log(`Injected retry wrapper into: ${out}`);
+}
+
 await mkdir(outdir, { recursive: true });
 
-const common = {
-  bundle: true,
-  platform: "node",
-  target: "node18",
-  format: "cjs",
-  external: ["openclaw/*"],
-  sourcemap: true,
-  logLevel: "info",
-};
-
 await Promise.all([
-  build({
-    ...common,
-    entryPoints: [join(root, "dist", "index.js")],
-    outfile: join(outdir, "index.cjs"),
-  }),
-  build({
-    ...common,
-    entryPoints: [join(root, "dist", "setup-entry.js")],
-    outfile: join(outdir, "setup-entry.cjs"),
-  }),
+  buildCjs(join(root, "dist", "index.js"), join(outdir, "index.cjs")),
+  buildCjs(join(root, "dist", "setup-entry.js"), join(outdir, "setup-entry.cjs")),
 ]);
 
 console.log("CJS build complete:", outdir);

--- a/scripts/smoke-test-dist.js
+++ b/scripts/smoke-test-dist.js
@@ -44,6 +44,22 @@ async function runSmokeTest() {
       // but we can syntax-check them and verify they resolve to a CommonJS file.
       execSync(`node --check ${JSON.stringify(indexPath)}`, { stdio: 'inherit' });
       console.log(`OK: CJS runtime entry point parses: ${extension}`);
+
+      // Verify the ERR_REQUIRE_ESM_RACE_CONDITION retry wrapper is present
+      const cjsSource = readFileSync(indexPath, 'utf-8');
+      assert.ok(
+        cjsSource.includes('function __requireWithRetry(id)'),
+        `CJS entry ${extension} must contain __requireWithRetry helper (see issue #231)`
+      );
+      assert.ok(
+        cjsSource.includes('ERR_REQUIRE_ESM_RACE_CONDITION'),
+        `CJS entry ${extension} must handle ERR_REQUIRE_ESM_RACE_CONDITION (see issue #231)`
+      );
+      assert.ok(
+        cjsSource.includes('__requireWithRetry("openclaw/'),
+        `CJS entry ${extension} must wrap openclaw/* requires with retry`
+      );
+      console.log(`OK: CJS retry wrapper present in: ${extension}`);
     } else {
       const mod = await import(pathToFileURL(indexPath).href);
       assert.ok(mod.default, `Entry point ${extension} must have a default export`);


### PR DESCRIPTION
Closes #231.

## Problem

On Termux/Android with Node 24 LTS, the Zulip plugin fails to load with `ERR_REQUIRE_ESM_RACE_CONDITION`. The race is caused by concurrent `require()` and `import()` of the host-provided ESM SDK modules (`openclaw/plugin-sdk/*`). The CJS entry point keeps `openclaw/*` external, so it synchronously `require()`s those ESM modules at startup.

Upstream fixes are tracked at [openclaw/openclaw#83035](https://github.com/openclaw/openclaw/issues/83035) and [nodejs/node#62432](https://github.com/nodejs/node/issues/62432), but neither has a resolution yet.

## Solution: Bounded Synchronous Retry Wrapper

Instead of bundling the SDK (which risks version mismatch and duplicated singletons), this PR injects a local retry helper into the CJS bundle that catches `ERR_REQUIRE_ESM_RACE_CONDITION` on `openclaw/*` requires, busy-waits ~20 ms, and retries up to 5 times before giving up.

### Why this works

The race is **transient** — the ESM module is "not yet fully loaded" for only a few milliseconds while another loader thread finishes. A bounded synchronous retry with a short spin-loop allows the concurrent loader to finish.

### Trade-offs

- Synchronous busy-wait blocks the event loop briefly during startup (~100 ms worst case).
- If the race window exceeds 100 ms, the original error is re-thrown unchanged.
- Only affects `openclaw/*` modules; no global `require` monkey-patching.
- This is a workaround, not a root-cause fix. It should be removed once upstream resolves the race.

## Changes

- `scripts/build-cjs.js`: post-process esbuild output to inject `__requireWithRetry(id)` and replace `require("openclaw/...")` with `__requireWithRetry("openclaw/...")`.
- `scripts/smoke-test-dist.js`: assert the retry wrapper is present in CJS entries.

## Validation

- `npm run check` passes: 129 tests, 128 pass, 1 skip, 0 failures.
- Smoke test passes and confirms retry wrapper is present in `dist-cjs/index.cjs`.
- Container deployment planned after merge.

## Deployment note

This PR intentionally does **not** bump the version. It will be deployed to `lab-openclaw` for live validation after merge, and the Termux reporter (y6) will be asked to test a pre-release build.
