### PR TITLE
fix(runtime): global singleton + defensive channel API checks for Termux (#233)

### DIFF
--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -1,12 +1,13 @@
 import type { PluginRuntime } from "openclaw/plugin-sdk/channel-core";
 
-let runtime: PluginRuntime | null = null;
+const RUNTIME_KEY = "__openclaw_zulip_runtime__";
 
 export function setZulipRuntime(next: PluginRuntime) {
-  runtime = next;
+  (globalThis as any)[RUNTIME_KEY] = next;
 }
 
 export function getZulipRuntime(): PluginRuntime {
+  const runtime = (globalThis as any)[RUNTIME_KEY];
   if (!runtime) {
     throw new Error("Zulip runtime not initialized");
   }

--- a/src/zulip/monitor.ts
+++ b/src/zulip/monitor.ts
@@ -78,8 +78,10 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
       baseUrl,
     } = await initializeZulipMonitor({ opts, core });
 
-    const logger = core.logging.getChildLogger({ module: "zulip" });
-    const logVerboseMessage = core.logging.shouldLogVerbose()
+    const logger = core.logging?.getChildLogger
+      ? core.logging.getChildLogger({ module: "zulip" })
+      : null;
+    const logVerboseMessage = logger && core.logging?.shouldLogVerbose && core.logging.shouldLogVerbose()
       ? (message: string) => logger.debug?.(message)
       : () => {};
 
@@ -129,7 +131,9 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
 
     // Use full config from runtime instead of passed cfg to get channel settings
     // (fullCfg already loaded above at line ~90)
-    const mentionRegexes = core.channel.mentions.buildMentionRegexes(cfg, "main");
+    const mentionRegexes = core.channel.mentions?.buildMentionRegexes
+      ? core.channel.mentions.buildMentionRegexes(cfg, "main")
+      : [];
     const zulipSection = cfg.channels?.zulip;
     const accountSection = zulipSection?.accounts?.[account.accountId] ?? zulipSection ?? {};
     const dmPolicy = accountSection.dmPolicy ?? account.config.dmPolicy ?? "pairing";
@@ -273,7 +277,9 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
       const wasMentioned =
         !isDM &&
         (rawText.toLowerCase().includes(botUsernameMention) ||
-          core.channel.mentions.matchesMentionPatterns(rawText, mentionRegexes));
+          (core.channel.mentions?.matchesMentionPatterns
+            ? core.channel.mentions.matchesMentionPatterns(rawText, mentionRegexes)
+            : false));
 
       // ⚡ Performance: Use cached disk-based allowlist (30s TTL)
       let senderAllowedForCommands = isSenderAllowed({


### PR DESCRIPTION
Closes #233.

## Problem

On Node 24 / Termux (y6), the Zulip plugin loads successfully after the CJS retry wrapper (#232), but the channel monitor fails immediately with `TypeError: Cannot read properties of undefined (reading 'mentions')`.

Root cause: the OpenClaw host loads the plugin module multiple times (once for `registerFull`, once for `startAccount`). Each load creates a separate module-level scope for `src/runtime.ts`. The `registerFull` call sets the runtime in one scope, but `getZulipRuntime()` in the monitor reads from a different scope where the singleton is still `null`.

## Solution

1. **Global runtime singleton**: store the runtime in `globalThis.__openclaw_zulip_runtime__` instead of a module-level `let`. This survives module re-evaluation regardless of how many times the host loads the plugin.

2. **Defensive `core.logging`**: `core.logging?.getChildLogger` is checked before use. On OpenClaw 2026.7.1-2 (y6) this API is missing; we fall back to `null` logger.

3. **Defensive `core.channel.mentions`**: `core.channel.mentions?.buildMentionRegexes` and `matchesMentionPatterns` are checked before use. On OpenClaw 2026.7.1-2 (y6) this API is missing; we fall back to empty regex list and `false` for mention matching.

## Validation

- `npm run check` passes: 129 tests, 128 pass, 1 skip, 0 failures.
- Deployed to y6 (Termux / Node 24.17.0 / OpenClaw 2026.7.1-2):
  - Channel status: `running, connected`
  - No `getChildLogger` errors
  - No `mentions` errors
  - Monitor stays alive across multiple health-monitor cycles

## Deployment

Deployed to `lab-openclaw` (container) and y6 (Termux) without regressions.
