### PR TITLE
fix: disable humanDelay to show typing indicator immediately

### DIFF
--- a/src/zulip/reply-handler.ts
+++ b/src/zulip/reply-handler.ts
@@ -110,7 +110,7 @@ export async function dispatchZulipReply(params: {
   const { dispatcher, replyOptions, markDispatchIdle } =
     core.channel.reply.createReplyDispatcherWithTyping({
       ...prefixOptions,
-      humanDelay: core.channel.reply.resolveHumanDelayConfig(cfg, route.agentId),
+      humanDelay: 0,
       onReplyStart: typingCallbacks.onReplyStart,
       deliver: async (payload: ReplyPayload) => {
         deliveredAny = true;
@@ -270,10 +270,14 @@ export async function dispatchZulipReply(params: {
 
   let dispatchError: unknown;
   const dispatchStartTime = new Date().toISOString();
-  core.logging?.getChildLogger?.({ module: "zulip" })?.info?.("zulip dispatch start", {
+  const dispatchStartMs = Date.now();
+  const zLogger = core.logging?.getChildLogger?.({ module: "zulip" });
+  zLogger?.info?.("zulip dispatch start", {
     accountId: account.accountId,
     messageId,
     sessionKey: route?.sessionKey ?? route?.mainSessionKey,
+    bodyLen: ctxPayload?.Body?.length ?? 0,
+    rawBodyLen: ctxPayload?.RawBody?.length ?? 0,
   });
   try {
     await core.channel.reply.dispatchReplyFromConfig({
@@ -286,6 +290,13 @@ export async function dispatchZulipReply(params: {
           typeof account.blockStreaming === "boolean" ? !account.blockStreaming : undefined,
         onModelSelected,
       },
+    });
+    const elapsedMs = Date.now() - dispatchStartMs;
+    zLogger?.info?.("zulip dispatch completed", {
+      accountId: account.accountId,
+      messageId,
+      elapsedMs,
+      deliveredAny,
     });
   } catch (err) {
     dispatchError = err;


### PR DESCRIPTION
## Summary

The SDK's `resolveHumanDelayConfig` has a built-in default of ~14s that delays the typing indicator. This makes the bot appear unresponsive for 14 seconds before showing "typing".

## Change

Set `humanDelay: 0` in `createReplyDispatcherWithTyping` so the typing indicator starts immediately when the LLM begins generating.

## Before/After

| Metric | Before (14s delay) | After (0s delay) |
|--------|-------------------|------------------|
| dispatch → typing start | ~16s | **~0.34s** |
| Total dispatch time | ~40s | ~20s (remaining is LLM + Honcho timeout) |

## Testing

- 131/132 tests passing
- Live-tested on y6: typing indicator now appears within 0.3s of dispatch