### PR TITLE
fix: remove unsupported securityExemptions field from manifest

### DIFF
--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -22,10 +22,6 @@
       }
     ]
   },
-  "securityExemptions": {
-    "envAccess": ["ZULIP_API_KEY", "ZULIP_EMAIL", "ZULIP_URL", "ZULIP_SITE", "ZULIP_REALM"],
-    "reason": "Zulip credentials from environment variables (documented pattern)"
-  },
   "configSchema": {
     "type": "object",
     "additionalProperties": false,


### PR DESCRIPTION
## Summary

ClawHub validator flagged `securityExemptions` as an unsupported top-level field in `openclaw.plugin.json` (warning: `manifest-unknown-fields`).

## Change

Removed the `securityExemptions` block from `openclaw.plugin.json`. The env vars are already properly declared in `setup.providers.envVars`. The `securityExemptions` field remains in `package.json` under `openclaw.securityExemptions` where it is supported.

## Testing

- 131/132 tests passing
- Deployed and validated on container: `clawhub package validate` no longer flags it