### PR TITLE
fix: describeMessageTool returns plugin metadata instead of calling getChatChannelMeta

### DIFF
--- a/src/actions.ts
+++ b/src/actions.ts
@@ -6,8 +6,8 @@ import {
   readNumberParam,
   readStringParam,
 } from "openclaw/plugin-sdk/channel-core";
-import { getChatChannelMeta } from "openclaw/plugin-sdk/core";
 import { resolveZulipAccount } from "./zulip/accounts.js";
+import { zulipChannelMeta } from "./channel.js";
 import {
   addZulipReaction,
   createZulipClient,
@@ -398,7 +398,7 @@ function readRealmUpdateParams(
 
 export const zulipMessageActions: ChannelMessageActionAdapter = {
   describeMessageTool: () => {
-    return getChatChannelMeta("zulip");
+    return zulipChannelMeta;
   },
   listActions: ({ cfg }) => {
     const accounts = [resolveZulipAccount({ cfg })].filter((account) =>

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -1,6 +1,5 @@
 import {
   createChatChannelPlugin,
-  getChatChannelMeta,
   deleteAccountFromConfigSection,
   setAccountEnabledInConfigSection,
   formatPairingApproveHint,
@@ -29,7 +28,7 @@ import { maskPII, formatZulipLog } from "./zulip/monitor-helpers.js";
 import { probeZulip } from "./zulip/probe.js";
 import { sendMessageZulip } from "./zulip/send.js";
 
-const meta = {
+export const zulipChannelMeta = {
   id: "zulip",
   label: "Zulip",
   selectionLabel: "Zulip (plugin)",
@@ -66,7 +65,7 @@ export const zulipPlugin = createChatChannelPlugin<ResolvedZulipAccount>({
   base: {
     id: "zulip",
     meta: {
-      ...meta,
+      ...zulipChannelMeta,
     },
     setup: zulipSetupAdapter,
     setupWizard: zulipSetupWizard,


### PR DESCRIPTION
## Summary

`describeMessageTool` was calling `getChatChannelMeta("zulip")` which always returns `undefined` because Zulip is a third-party plugin — the function only resolves first-party/bundled channel metadata.

## Fix

Exported `zulipChannelMeta` from `channel.ts` and return it directly from `describeMessageTool` in `actions.ts`. Removed the unused `getChatChannelMeta` import from both files.

## Testing

- 131/132 tests passing
- Deployed and validated on both container (`lab-openclaw`) and device (`y6`)
- `describeMessageTool` now returns valid metadata instead of `undefined`

Closes #230