### PR TITLE
chore: clean up comments, remove unused admin action handlers, bump to 2026.8.6

### DIFF
--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "zulip",
   "name": "Zulip",
   "description": "OpenClaw Zulip channel plugin",
-  "version": "2026.8.4",
+  "version": "2026.8.6",
   "activation": {
     "onStartup": true
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@niyazmft/openclaw-zulip",
-  "version": "2026.8.4",
+  "version": "2026.8.6",
   "description": "OpenClaw Zulip channel plugin",
   "type": "module",
   "packageManager": "pnpm@10.32.1",

--- a/src/actions-admin.ts
+++ b/src/actions-admin.ts
@@ -4,35 +4,20 @@ import type { ZulipClient } from "./zulip/client.js";
 import {
   splitStreamTarget,
   readStreamId,
-  readUserIdParam,
-  readUserIdOrEmailParam,
   readBooleanParam,
   parseStringArrayParam,
-  readRealmUpdateParams,
-  resolveTopicName,
-  readMessageId,
   assertStringLength,
   requireAdminActionsEnabled,
-  requireZulipAdmin,
   MAX_STRING_LENGTH,
 } from "./actions-utils.js";
 import {
   fetchZulipSubscriptions,
   fetchZulipStreams,
-  subscribeZulipStream,
   createZulipStream,
   updateZulipStream,
   resolveZulipStreamId,
   deleteZulipStream,
   fetchZulipMemberInfo,
-  fetchZulipUserPresence,
-  deactivateZulipUser,
-  reactivateZulipUser,
-  fetchZulipServerSettings,
-  updateZulipRealm,
-  inviteZulipUsersToStream,
-  fetchZulipMessages,
-  updateZulipMessageTopic,
 } from "./zulip/client.js";
 
 export async function handleChannelListAction(
@@ -53,19 +38,6 @@ export async function handleChannelListAction(
     subscriptions,
     ...(publicStreams ? { publicStreams } : {}),
   });
-}
-
-export async function handleChannelSubscribeAction(
-  client: ZulipClient,
-  params: Record<string, unknown>,
-) {
-  const raw =
-    readStringParam(params, "stream") ??
-    readStringParam(params, "channelId") ??
-    readStringParam(params, "to", { required: true });
-  const target = splitStreamTarget(raw);
-  const result = await subscribeZulipStream(client, target.stream);
-  return jsonResult({ ok: true, stream: target.stream, result });
 }
 
 export async function handleChannelCreateAction(
@@ -206,178 +178,4 @@ export async function handleMemberInfoAction(
     readStringParam(params, "user");
   const user = await fetchZulipMemberInfo(client, userId ?? undefined);
   return jsonResult({ ok: true, user });
-}
-
-export async function handleUserPresenceAction(
-  client: ZulipClient,
-  params: Record<string, unknown>,
-) {
-  const userIdOrEmail = readUserIdOrEmailParam(params);
-  const presence = await fetchZulipUserPresence(client, userIdOrEmail);
-  return jsonResult({ ok: true, user: userIdOrEmail, presence });
-}
-
-export async function handleUserDeactivateAction(
-  client: ZulipClient,
-  params: Record<string, unknown>,
-  account: ResolvedZulipAccount,
-) {
-  requireAdminActionsEnabled(account);
-  await requireZulipAdmin(client);
-  const confirm = readBooleanParam(params, "confirm", "confirmed", "acknowledge");
-  if (confirm !== true) {
-    throw new Error(
-      "User deactivation requires confirm: true. " +
-      "This action disables the user's Zulip account and removes their login access.",
-    );
-  }
-  const userId = readUserIdParam(params);
-  await deactivateZulipUser(client, userId);
-  return jsonResult({ ok: true, userId, deactivated: true });
-}
-
-export async function handleUserReactivateAction(
-  client: ZulipClient,
-  params: Record<string, unknown>,
-  account: ResolvedZulipAccount,
-) {
-  requireAdminActionsEnabled(account);
-  await requireZulipAdmin(client);
-  const confirm = readBooleanParam(params, "confirm", "confirmed", "acknowledge");
-  if (confirm !== true) {
-    throw new Error(
-      "User reactivation requires confirm: true. " +
-      "This action restores a previously deactivated Zulip user account.",
-    );
-  }
-  const userId = readUserIdParam(params);
-  await reactivateZulipUser(client, userId);
-  return jsonResult({ ok: true, userId, reactivated: true });
-}
-
-export async function handleOrgSettingsAction(
-  client: ZulipClient,
-  params: Record<string, unknown>,
-) {
-  const settings = await fetchZulipServerSettings(client);
-  return jsonResult({ ok: true, settings });
-}
-
-export async function handleOrgSettingsEditAction(
-  client: ZulipClient,
-  params: Record<string, unknown>,
-  account: ResolvedZulipAccount,
-) {
-  requireAdminActionsEnabled(account);
-  await requireZulipAdmin(client);
-  const confirm = readBooleanParam(params, "confirm", "confirmed", "acknowledge");
-  if (confirm !== true) {
-    throw new Error(
-      "Organization settings update requires confirm: true. " +
-      "This action modifies global Zulip realm configuration.",
-    );
-  }
-  const updates = readRealmUpdateParams(params);
-  await updateZulipRealm(client, updates);
-  return jsonResult({ ok: true, updated: Object.keys(updates) });
-}
-
-export async function handleInviteAction(
-  client: ZulipClient,
-  params: Record<string, unknown>,
-) {
-  const raw =
-    readStringParam(params, "stream") ??
-    readStringParam(params, "channelId") ??
-    readStringParam(params, "to", { required: true });
-  const target = splitStreamTarget(raw);
-  let principals =
-    parseStringArrayParam(params, "principals") ??
-    parseStringArrayParam(params, "principal") ??
-    parseStringArrayParam(params, "userIds") ??
-    parseStringArrayParam(params, "users");
-  // Support comma-separated string for userId param (message tool compat)
-  if ((!principals || principals.length === 0) && typeof params.userId === "string") {
-    principals = params.userId
-      .split(",")
-      .map((s: string) => s.trim())
-      .filter(Boolean);
-  }
-  if (!principals || principals.length === 0) {
-    throw new Error("principals are required to invite Zulip users to a stream.");
-  }
-  for (const principal of principals) {
-    if (typeof principal === "string") {
-      assertStringLength(principal, "principal", MAX_STRING_LENGTH);
-    }
-  }
-  await inviteZulipUsersToStream(client, {
-    stream: target.stream,
-    principals,
-  });
-  return jsonResult({ ok: true, stream: target.stream, principals });
-}
-
-export async function handleResolveTopicAction(
-  client: ZulipClient,
-  params: Record<string, unknown>,
-) {
-  const explicitTopic = readStringParam(params, "topic") ?? readStringParam(params, "subject");
-  const rawStream =
-    readStringParam(params, "stream") ??
-    readStringParam(params, "channelId") ??
-    readStringParam(params, "to");
-  const target = rawStream ? splitStreamTarget(rawStream) : undefined;
-  const topic = explicitTopic ?? target?.topic;
-
-  if (!topic) {
-    throw new Error("topic is required to resolve a Zulip topic.");
-  }
-
-  assertStringLength(topic, "topic", MAX_STRING_LENGTH);
-  const { topic: resolvedTopic, alreadyResolved } = resolveTopicName(topic);
-  if (alreadyResolved) {
-    return jsonResult({ ok: true, topic, resolvedTopic, alreadyResolved: true });
-  }
-
-  const messageId = (() => {
-    try {
-      return readMessageId(params);
-    } catch {
-      return undefined;
-    }
-  })();
-
-  let targetMessageId = messageId;
-  if (!targetMessageId) {
-    if (!target?.stream) {
-      throw new Error(
-        "stream is required to resolve a Zulip topic when messageId is not provided.",
-      );
-    }
-    const messages = await fetchZulipMessages(client, {
-      stream: target.stream,
-      topic,
-      limit: 1,
-    });
-    const latest = messages[0];
-    if (!latest?.id) {
-      throw new Error("No messages found for the specified stream/topic.");
-    }
-    targetMessageId = String(latest.id);
-  }
-
-  await updateZulipMessageTopic(client, {
-    messageId: targetMessageId,
-    topic: resolvedTopic,
-    propagateMode: "change_all",
-  });
-
-  return jsonResult({
-    ok: true,
-    stream: target?.stream,
-    topic,
-    resolvedTopic,
-    messageId: targetMessageId,
-  });
 }

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -16,18 +16,10 @@ import {
 } from "./actions-messages.js";
 import {
   handleChannelListAction,
-  handleChannelSubscribeAction,
   handleChannelCreateAction,
   handleChannelEditAction,
   handleChannelDeleteAction,
   handleMemberInfoAction,
-  handleUserPresenceAction,
-  handleUserDeactivateAction,
-  handleUserReactivateAction,
-  handleOrgSettingsAction,
-  handleOrgSettingsEditAction,
-  handleInviteAction,
-  handleResolveTopicAction,
 } from "./actions-admin.js";
 
 export const zulipMessageActions: ChannelMessageActionAdapter = {
@@ -56,17 +48,6 @@ export const zulipMessageActions: ChannelMessageActionAdapter = {
       "pin",
       "unpin",
     ]);
-    // TODO: These actions require core SDK changes to MESSAGE_ACTION_TARGET_MODE.
-    // Re-enable once the SDK supports plugin-registered action target modes.
-    // See: https://github.com/openclaw/openclaw/issues/TBD
-    // actions.add("channel-subscribe" as ChannelMessageActionName);
-    // actions.add("invite" as ChannelMessageActionName);
-    // actions.add("resolve-topic" as ChannelMessageActionName);
-    // actions.add("user-presence" as ChannelMessageActionName);
-    // actions.add("user-deactivate" as ChannelMessageActionName);
-    // actions.add("user-reactivate" as ChannelMessageActionName);
-    // actions.add("org-settings" as ChannelMessageActionName);
-    // actions.add("org-settings-edit" as ChannelMessageActionName);
     return Array.from(actions);
   },
   extractToolSend: ({ args }) => {
@@ -92,10 +73,6 @@ export const zulipMessageActions: ChannelMessageActionAdapter = {
       return handleChannelListAction(client, params);
     }
 
-    if ((action as string) === "channel-subscribe") {
-      return handleChannelSubscribeAction(client, params);
-    }
-
     if (action === "channel-create") {
       return handleChannelCreateAction(client, params, account);
     }
@@ -110,30 +87,6 @@ export const zulipMessageActions: ChannelMessageActionAdapter = {
 
     if (action === "member-info") {
       return handleMemberInfoAction(client, params);
-    }
-
-    if ((action as string) === "user-presence") {
-      return handleUserPresenceAction(client, params);
-    }
-
-    if ((action as string) === "user-deactivate") {
-      return handleUserDeactivateAction(client, params, account);
-    }
-
-    if ((action as string) === "user-reactivate") {
-      return handleUserReactivateAction(client, params, account);
-    }
-
-    if ((action as string) === "org-settings") {
-      return handleOrgSettingsAction(client, params);
-    }
-
-    if ((action as string) === "org-settings-edit") {
-      return handleOrgSettingsEditAction(client, params, account);
-    }
-
-    if ((action as string) === "invite") {
-      return handleInviteAction(client, params);
     }
 
     if (action === "read") {
@@ -154,10 +107,6 @@ export const zulipMessageActions: ChannelMessageActionAdapter = {
 
     if (action === "pin" || action === "unpin") {
       return handlePinAction(client, params, action);
-    }
-
-    if ((action as string) === "resolve-topic") {
-      return handleResolveTopicAction(client, params);
     }
 
     if (action === "search") {

--- a/src/zulip/dedupe-store.ts
+++ b/src/zulip/dedupe-store.ts
@@ -10,7 +10,6 @@ export type DedupeStoreOpts = {
   maxSize: number;
 };
 
-// ⚡ Bolt Optimization: Debounce disk I/O to avoid synchronous writes on every message
 const SAVE_DEBOUNCE_MS = 5000; // Save at most once every 5 seconds
 
 export class ZulipDedupeStore {
@@ -82,7 +81,6 @@ export class ZulipDedupeStore {
   }
 
   /**
-   * ⚡ Bolt Optimization: Simple timeout-based debounce - no promises to avoid memory leaks
    */
   private scheduleSave(): void {
     this.dirty = true;
@@ -99,7 +97,6 @@ export class ZulipDedupeStore {
   }
 
   /**
-   * ⚡ Bolt Optimization: Flush pending saves immediately (for graceful shutdown)
    */
   async flush(): Promise<void> {
     if (this.saveTimeout) {
@@ -129,7 +126,6 @@ export class ZulipDedupeStore {
 
     this.touch(key, now);
     this.prune(now);
-    // ⚡ Bolt Optimization: Debounce save to avoid disk I/O on every message
     // Don't await - let it run in background with debounce
     this.scheduleSave();
     return false;

--- a/src/zulip/monitor-helpers.ts
+++ b/src/zulip/monitor-helpers.ts
@@ -41,7 +41,6 @@ export function resolveThreadSessionKeys(params: {
  * Formats a log message with standardized, machine-parseable identifiers.
  */
 export function formatZulipLog(message: string, fields: Record<string, unknown>): string {
-  // ⚡ Bolt Optimization: Use a single for...in loop to build the string
   // This avoids intermediate array allocations and redundant iterations
   // caused by Object.entries().filter().map().join(), making it ~5x faster.
   let parts = "";
@@ -125,7 +124,6 @@ export function delay(ms: number): Promise<void> {
 
 /**
  * Compute and track conversation metadata for inbound messages.
- * Issue #211: conversation_turn, session_gap_seconds, topic_changed
  */
 export function trackConversationMetadata(params: {
   sessionKey: string;

--- a/src/zulip/monitor.ts
+++ b/src/zulip/monitor.ts
@@ -123,11 +123,9 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
     });
     await dedupeStore.load();
 
-    // Issue #211: Conversation metadata tracking (conversation_turn, session_gap_seconds, topic_changed)
     const messageCounts = new Map<string, number>();
     const lastMessageTimes = new Map<string, number>();
     const lastTopicCache = new Map<string, string>();
-    // Issue #222: Track inbound DM message counts against the unrotated base
     // session key so we can rotate DM sessions before context bloat accumulates.
     const dmBaseMessageCounts = new Map<string, number>();
 
@@ -144,7 +142,6 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
     const defaultGroupPolicy = cfg.channels?.defaults?.groupPolicy;
     const groupPolicy = accountSection.groupPolicy ?? account.config.groupPolicy ?? defaultGroupPolicy ?? "allowlist";
 
-    // ⚡ Bolt Optimization: Lazily evaluate readAllowFromStore
     // Pre-compute the fallback for groupAllowFrom, but defer disk read until needed.
     // This avoids disk I/O for messages where sender is already authorized by static config.
     const configGroupAllowFromFallback = configGroupAllowFrom.length > 0 ? configGroupAllowFrom : configAllowFrom;
@@ -205,10 +202,8 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
       accountId: account.accountId,
     });
 
-    // ⚡ Bolt Optimization: Cache lowercase mention prefix AND pre-compiled regex outside the event loop
     // to prevent redundant string allocations and .toLowerCase() calls for every message.
     const botUsernameMention = `@${botUsername.toLowerCase()}`;
-    // ⚡ Bolt Optimization: Pre-compile regex using shared helper to avoid duplication
     // Guard against null/undefined botUsername to prevent TypeError
     const botUsernameMentionRegex = botUsername 
       ? createBotMentionRegex(botUsername)
@@ -470,11 +465,9 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
         },
       });
 
-      // Issue #222: Rotate Zulip DM session keys after a configured number of
       // inbound turns so one long/broken conversation cannot bloat context for
       // every future message in the same DM. Streams and topics keep stable keys.
       let baseSessionKey = route.sessionKey ?? `zulip:${account.accountId}:${channelId}`;
-      // Issue #246: If this is a recovery dispatch, use a fresh session key
       // to avoid the dead session from the previous gateway instance.
       if ((message as any)._recoverySessionKey) {
         baseSessionKey = (message as any)._recoverySessionKey;
@@ -496,7 +489,6 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
       });
       const sessionKey = threadKeys.sessionKey;
 
-      // Issue #211: Compute conversation metadata (conversation_turn, session_gap_seconds, topic_changed)
       const { conversationTurn, sessionGapSeconds, topicChanged } = trackConversationMetadata({
         sessionKey,
         channelId,
@@ -588,7 +580,6 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
         MediaUrls: mediaUrls.length > 0 ? mediaUrls : undefined,
         MediaType: mediaTypes[0],
         MediaTypes: mediaTypes.length > 0 ? mediaTypes : undefined,
-        // Issue #211: Context metadata for agent
         ConversationTurn: conversationTurn,
         SessionGapSeconds: sessionGapSeconds,
         TopicChanged: topicChanged,
@@ -622,7 +613,6 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
         preview: maskPII(previewLine),
       });
 
-      // Issue #224: Start reaction is best-effort; don't block model inference
       // on the Zulip API round-trip.
       logger?.info?.("zulip reaction add start", {
         accountId: account.accountId,
@@ -696,7 +686,6 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
             reactionsEnabled,
             logVerbose: logVerboseMessage,
           });
-          // Issue #212: Best-effort cleanup orphaned placeholder on dispatch error
           if (placeholderPromise) {
             void (async () => {
               const phId = placeholderMessageId ?? (await placeholderPromise.catch(() => undefined));
@@ -781,7 +770,6 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
       }
     };
 
-    // Issue #246: Recover interrupted messages after gateway restart.
     // Scan recent DMs for messages with stale 👀 reactions (no ✅/⚠️, no response).
     // This runs once on startup before the main polling loop.
     try {
@@ -858,7 +846,6 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
         await deleteZulipQueue(client, queue.queueId);
       }
     }
-    // Issue #237: Flush dedupe store on graceful shutdown to prevent
     // duplicate message processing after restart.
     await dedupeStore.flush();
   } catch (err) {

--- a/src/zulip/polling.ts
+++ b/src/zulip/polling.ts
@@ -58,7 +58,6 @@ export async function pollOnce(params: {
         response.code === "BAD_EVENT_QUEUE_ID" || msg.toLowerCase().includes("bad event queue");
       if (isBadQueue) {
         await queueManager.markQueueExpired();
-        // Issue #245: Apply backoff on bad-queue recovery to avoid rapid-fire
         // /events requests that consume the rate-limit budget.
         const pLogger = core.logging?.getChildLogger?.({ module: "zulip" });
         pLogger?.info?.("zulip poll throttle: bad queue (error response), waiting 1s", {
@@ -89,7 +88,6 @@ export async function pollOnce(params: {
       lastConnectedAt: Date.now(),
     });
 
-    // Issue #245: Apply 1s delay when no message-type events were processed,
     // not only when the events array is empty. Heartbeat events (non-message)
     // should not trigger an immediate re-poll.
     const hadMessageEvents = events.some((e: any) => e.type === "message" && e.message);
@@ -136,7 +134,6 @@ export async function pollOnce(params: {
       void Promise.all(processing);
     } finally {
       if (maxEventId > 0) {
-        // ⚡ Bolt Optimization: Batch disk I/O updates for event ID
         // Previously, we updated the queue manager (which writes to disk) for every event.
         // By keeping track of the maxEventId and updating once per batch, we turn
         // O(N) disk writes into O(1) writes, drastically reducing I/O operations.
@@ -151,7 +148,6 @@ export async function pollOnce(params: {
     const errStr = String(err);
     if (errStr.toLowerCase().includes("bad event queue")) {
       await queueManager.markQueueExpired();
-      // Issue #245: Apply backoff on bad-queue recovery to avoid rapid-fire
       // /events requests that consume the rate-limit budget.
       const pLogger = core.logging?.getChildLogger?.({ module: "zulip" });
       pLogger?.info?.("zulip poll throttle: bad queue (exception path), waiting 1s", {

--- a/src/zulip/recovery.ts
+++ b/src/zulip/recovery.ts
@@ -139,7 +139,6 @@ export async function recoverInterruptedMessages(params: {
         senderEmail: maskPII(senderEmail),
       });
 
-      // Issue #246: Set a fresh session key so the re-dispatched message
       // creates a new session instead of reusing the dead one from the
       // previous gateway instance. The pattern matches what the host uses
       // for Zulip DM sessions: agent:{agentId}:zulip:direct:{email}

--- a/src/zulip/reply-handler.ts
+++ b/src/zulip/reply-handler.ts
@@ -122,7 +122,6 @@ export async function dispatchZulipReply(params: {
           hasMedia: Boolean(payload.mediaUrl || payload.mediaUrls?.length),
         });
         try {
-          // Issue #224: Stop the typing indicator as soon as the first chunk is
           // delivered so the user does not see "bot is typing" after the reply
           // is already visible. This is best-effort and idempotent.
           if (!typingStopped) {
@@ -257,7 +256,6 @@ export async function dispatchZulipReply(params: {
     },
       onError: (err: unknown) => {
         core.error?.(`zulip reply failed: ${String(err)}`);
-        // Issue #224: Ensure typing indicator stops promptly on dispatch error.
         if (!typingStopped) {
           typingStopped = true;
           const idleResult = typingCallbacks.onIdle();

--- a/src/zulip/text-utils.ts
+++ b/src/zulip/text-utils.ts
@@ -3,7 +3,6 @@ const DEFAULT_ONCHAR_PREFIXES = [">", "!"];
 const HTML_TAG_REGEX = /<[^>]+>/g;
 const MENTION_REGEX = /@\*\*([^*]+)\*\*/g;
 
-// ⚡ Bolt Optimization: Single-pass HTML entity replacement
 // Combined regex for all common entities - avoids 4 separate .replace() passes
 const HTML_ENTITY_REGEX = /&(lt|gt|amp|quot);/g;
 const HTML_ENTITY_MAP: Record<string, string> = {
@@ -13,7 +12,6 @@ const HTML_ENTITY_MAP: Record<string, string> = {
   '&quot;': '"',
 };
 
-// ⚡ Bolt Optimization: Pre-compile regex for bot mention matching
 // Exported for callers who want to cache the regex at initialization time
 export function createBotMentionRegex(botUsername: string): RegExp {
   const escaped = botUsername.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
@@ -22,7 +20,6 @@ export function createBotMentionRegex(botUsername: string): RegExp {
 
 /**
  * Strips HTML tags and unescapes common HTML entities from Zulip message content.
- * ⚡ Bolt Optimization: Single-pass entity replacement reduces string processing
  */
 export function stripHtmlToText(html: string): string {
   if (!html.includes('<') && !html.includes('&') && !html.includes('@**')) {
@@ -50,7 +47,6 @@ export function normalizeMention(text: string, mention: string | RegExp | undefi
     return text.replace(/\s+/g, " ").trim();
   }
   
-  // ⚡ Bolt Optimization: Use pre-compiled regex if provided (avoids per-message allocation)
   // Falls back to creating regex from string for backward compatibility
   const re = mention instanceof RegExp 
     ? mention 

--- a/test/monitor-metadata.test.ts
+++ b/test/monitor-metadata.test.ts
@@ -213,7 +213,6 @@ test("reply-handler source: typing indicator stops on first chunk delivery", asy
 
 test("monitor source: start reaction is fire-and-forget", async () => {
   const source = await fs.readFile(monitorPath, "utf8");
-  assert.equal(source.includes("Issue #224"), true);
   assert.equal(source.includes("void addReactionSafe({"), true);
 });
 

--- a/test/polling.test.ts
+++ b/test/polling.test.ts
@@ -1,7 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-// ── Regression tests for Issue #245 ─────────────────────────────────────────
 // The fix: polling loop should apply a 1s delay when:
 // 1. Events are present but none are message-type (heartbeat-only responses)
 // 2. Bad-queue recovery path (both structured error and exception paths)
@@ -98,5 +97,5 @@ test("polling source: bad-queue recovery uses backoffMs", async () => {
   assert.equal(source.includes('return { pollBackoffMs: 0, shouldContinue: true }'), false);
   // The new pattern should be present
   assert.equal(source.includes("backoffMs"), true);
-  assert.equal(source.includes("Issue #245"), true);
+  assert.equal(source.includes("hadMessageEvents"), true);
 });


### PR DESCRIPTION
## Summary

Cleanup and version bump for v2026.8.6 release.

### Changes
- Remove all Issue # and Bolt Optimization comments from source and tests
- Remove unused admin action handlers (channel-subscribe, user-presence, user-deactivate, user-reactivate, org-settings, org-settings-edit, invite, resolve-topic) and their imports
- Remove TODO comments for disabled actions from actions.ts
- Bump version to 2026.8.6

### Verification
- 207 tests pass, 0 failures
- Typecheck clean
- Build succeeds (ESM + CJS)
- Deployed and verified on both container and y6