### PR TITLE
feat: fire message_received hook for Honcho sender attribution

### DIFF
--- a/src/zulip/monitor.ts
+++ b/src/zulip/monitor.ts
@@ -3,6 +3,13 @@ import { logInboundDrop } from "openclaw/plugin-sdk/channel-inbound";
 import { resolveControlCommandGate } from "openclaw/plugin-sdk/command-auth";
 import { createReplyPrefixOptions } from "openclaw/plugin-sdk/channel-reply-options-runtime";
 import { resolveChannelMediaMaxBytes } from "openclaw/plugin-sdk/media-runtime";
+import {
+  deriveInboundMessageHookContext,
+  fireAndForgetBoundedHook,
+  toPluginMessageContext,
+  toPluginMessageReceivedEvent,
+} from "openclaw/plugin-sdk/hook-runtime";
+import { getGlobalHookRunner } from "openclaw/plugin-sdk/plugin-runtime";
 import { getZulipRuntime } from "../runtime.js";
 import {
   deleteZulipQueue,
@@ -598,6 +605,29 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
             to,
             accountId: route.accountId,
           },
+        });
+      }
+
+      // Fire message_received hook so plugins (e.g. Honcho memory) can
+      // capture sender attribution before OpenClaw strips the metadata block.
+      try {
+        const canonical = deriveInboundMessageHookContext(ctxPayload);
+        const hookRunner = getGlobalHookRunner();
+        if (hookRunner?.hasHooks?.("message_received")) {
+          fireAndForgetBoundedHook(
+            () =>
+              hookRunner.runMessageReceived(
+                toPluginMessageReceivedEvent(canonical),
+                toPluginMessageContext(canonical),
+              ),
+            "zulip: message_received plugin hook failed",
+          );
+        }
+      } catch (hookErr) {
+        logger?.debug?.("zulip message_received hook error", {
+          accountId: account.accountId,
+          messageId,
+          error: String(hookErr),
         });
       }
 

--- a/test/openclaw-plugin-sdk-shim.js
+++ b/test/openclaw-plugin-sdk-shim.js
@@ -73,3 +73,63 @@ export const MarkdownConfigSchema = zodMock;
 export const DmPolicySchema = zodMock;
 export const GroupPolicySchema = zodMock;
 export const BlockStreamingCoalesceSchema = zodMock;
+
+// Hook runtime stubs
+export const deriveInboundMessageHookContext = (ctx) => ({
+  from: ctx.From ?? '',
+  to: ctx.To,
+  content: ctx.RawBody ?? ctx.Body ?? '',
+  body: ctx.Body,
+  timestamp: typeof ctx.Timestamp === 'number' ? ctx.Timestamp : undefined,
+  channelId: 'zulip',
+  accountId: ctx.AccountId,
+  conversationId: ctx.OriginatingTo ?? ctx.To ?? ctx.From,
+  sessionKey: ctx.SessionKey,
+  messageId: ctx.MessageSid,
+  senderId: ctx.SenderId,
+  senderName: ctx.SenderName,
+  senderUsername: ctx.SenderUsername,
+  provider: ctx.Provider,
+  surface: ctx.Surface,
+  isGroup: Boolean(ctx.GroupSubject || ctx.GroupChannel),
+  groupId: Boolean(ctx.GroupSubject || ctx.GroupChannel) ? (ctx.OriginatingTo ?? ctx.To ?? ctx.From) : undefined,
+});
+
+export const fireAndForgetBoundedHook = (fn, label, _timeoutOrUndefined, _limits) => {
+  try {
+    const result = fn();
+    if (result && typeof result.catch === 'function') {
+      result.catch(() => {});
+    }
+  } catch {}
+};
+
+export const toPluginMessageReceivedEvent = (canonical) => ({
+  from: canonical.from,
+  content: canonical.content,
+  timestamp: canonical.timestamp,
+  messageId: canonical.messageId,
+  senderId: canonical.senderId,
+  sessionKey: canonical.sessionKey,
+  metadata: {
+    provider: canonical.provider,
+    surface: canonical.surface,
+    senderId: canonical.senderId,
+    senderName: canonical.senderName,
+  },
+});
+
+export const toPluginMessageContext = (canonical) => ({
+  channelId: canonical.channelId,
+  accountId: canonical.accountId,
+  conversationId: canonical.conversationId,
+  sessionKey: canonical.sessionKey,
+  messageId: canonical.messageId,
+  senderId: canonical.senderId,
+});
+
+export const getGlobalHookRunner = () => null;
+
+export const createInternalHookEvent = () => ({});
+export const toInternalMessageReceivedContext = () => ({});
+export const triggerInternalHook = () => {};

--- a/types/openclaw-plugin-sdk.d.ts
+++ b/types/openclaw-plugin-sdk.d.ts
@@ -146,6 +146,20 @@ declare module "openclaw/plugin-sdk/setup-runtime" {
   export const createSetupInputPresenceValidator: any;
 }
 
+declare module "openclaw/plugin-sdk/hook-runtime" {
+  export const deriveInboundMessageHookContext: any;
+  export const fireAndForgetBoundedHook: any;
+  export const createInternalHookEvent: any;
+  export const toInternalMessageReceivedContext: any;
+  export const toPluginMessageContext: any;
+  export const toPluginMessageReceivedEvent: any;
+  export const triggerInternalHook: any;
+}
+
+declare module "openclaw/plugin-sdk/plugin-runtime" {
+  export const getGlobalHookRunner: any;
+}
+
 declare module "openclaw/plugin-sdk/zod" {
   export const z: any;
 }


### PR DESCRIPTION
## Summary

The Zulip plugin now emits `message_received` hooks via the SDK's `hook-runtime` after building the inbound context payload. This allows plugins like Honcho memory to capture sender attribution **before** OpenClaw strips the metadata block from message text.

## Problem

The Zulip plugin bypassed the standard inbound event pipeline (used by Telegram, WhatsApp, Discord) and called `dispatchReplyFromConfig` directly. This meant:
- No `message_received` hook was ever fired for Zulip messages
- The Honcho plugin could not extract sender IDs from Zulip messages
- All Zulip users were attributed to the `owner` peer instead of their correct user peer

## Fix

After building the `ctxPayload` via `finalizeInboundContext`, the plugin now:
1. Derives a canonical hook context via `deriveInboundMessageHookContext(ctxPayload)`
2. Checks if any plugin has registered a `message_received` handler
3. If so, fires the hook via `fireAndForgetBoundedHook` with `runMessageReceived(event, context)`

This matches the pattern used by WhatsApp and other first-party channel plugins.

## Files changed

- `src/zulip/monitor.ts` — Added imports and hook emission after ctxPayload construction
- `types/openclaw-plugin-sdk.d.ts` — Added type declarations for `hook-runtime` and `plugin-runtime` modules
- `test/openclaw-plugin-sdk-shim.js` — Added test stubs for hook runtime functions

## Note

The Honcho plugin also needs to be updated to listen for `message_received` hooks (see plastic-labs/openclaw-honcho#92). Without that, the hook fires but no consumer processes it.

Closes #252