### PR TITLE
fix(security): make session recovery opt-in with enableSessionRecovery config (#254)

### DIFF
--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -112,6 +112,7 @@
             "type": "integer",
             "minimum": 0
           },
+          "enableSessionRecovery": { "type": "boolean" },
           "accounts": {
             "type": "object",
             "additionalProperties": true
@@ -295,6 +296,10 @@
         "dmSessionTurnLimit": {
           "label": "DM session turn limit",
           "description": "Maximum inbound conversation turns in a single Zulip DM session before starting a fresh session. Prevents one long/broken conversation from bloating context for all future replies. 0 disables rotation."
+        },
+        "enableSessionRecovery": {
+          "label": "Enable session recovery",
+          "description": "When enabled, the bot scans recent DMs on startup for messages interrupted by a gateway restart and re-dispatches them. Default: disabled (opt-in)."
         }
       }
     }

--- a/src/config-schema.ts
+++ b/src/config-schema.ts
@@ -49,6 +49,7 @@ const ZulipAccountSchema = z.object({
   autoSendOnMissingTool: z.boolean().optional(),
   showThinkingPlaceholder: z.boolean().optional(),
   dmSessionTurnLimit: z.number().int().min(0).optional(),
+  enableSessionRecovery: z.boolean().optional(),
 });
 
 const ZulipConfigSchema = buildCatchallMultiAccountChannelSchema(

--- a/src/config-ui-hints.ts
+++ b/src/config-ui-hints.ts
@@ -73,4 +73,8 @@ export const zulipChannelConfigUiHints = {
     label: "DM session turn limit",
     help: "Maximum inbound conversation turns in a single Zulip DM session before starting a fresh session. Prevents one long/broken conversation from bloating context for all future replies. 0 disables rotation.",
   },
+  enableSessionRecovery: {
+    label: "Enable session recovery",
+    help: "When enabled, the bot scans recent DMs on startup for messages interrupted by a gateway restart and re-dispatches them. Default: disabled (opt-in).",
+  },
 } satisfies Record<string, ZulipChannelConfigUiHint>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -97,6 +97,15 @@ export type ZulipAccountConfig = {
    * Default: 20.
    */
   dmSessionTurnLimit?: number;
+  /**
+   * Enable recovery of interrupted messages after a gateway restart.
+   * When true, the bot scans recent DMs for messages with a 👀 reaction
+   * but no ✅/⚠️ reaction and no bot response, then re-dispatches them
+   * with a fresh session key.
+   *
+   * Default: false (opt-in).
+   */
+  enableSessionRecovery?: boolean;
 };
 
 export type ZulipConfig = {

--- a/src/zulip/accounts.ts
+++ b/src/zulip/accounts.ts
@@ -31,6 +31,7 @@ export type ResolvedZulipAccount = {
   autoSendOnMissingTool?: boolean;
   showThinkingPlaceholder?: boolean;
   dmSessionTurnLimit?: number;
+  enableSessionRecovery?: boolean;
 };
 
 function resolveZulipSection(cfg: OpenClawConfig): ZulipConfig | undefined {
@@ -181,6 +182,7 @@ export function resolveZulipAccount(params: {
     autoSendOnMissingTool: merged.autoSendOnMissingTool,
     showThinkingPlaceholder: merged.showThinkingPlaceholder,
     dmSessionTurnLimit: merged.dmSessionTurnLimit,
+    enableSessionRecovery: merged.enableSessionRecovery,
   };
 }
 

--- a/src/zulip/monitor.ts
+++ b/src/zulip/monitor.ts
@@ -800,29 +800,35 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
       }
     };
 
-    // Scan recent DMs for messages with stale 👀 reactions (no ✅/⚠️, no response).
-    // This runs once on startup before the main polling loop.
-    try {
-      const { recoverInterruptedMessages } = await import("./recovery.js");
-      await recoverInterruptedMessages({
-        client,
-        botEmail,
-        botUserId,
-        botUsername,
-        baseUrl,
+    // Session recovery: scan recent DMs for messages with stale 👀 reactions
+    // (no ✅/⚠️, no response) and re-dispatch them with a fresh session key.
+    // Only runs when explicitly enabled by the user.
+    if (account.config.enableSessionRecovery === true) {
+      logger?.info?.("zulip session recovery is enabled — scanning recent DMs for interrupted messages", {
         accountId: account.accountId,
-        reactionStart,
-        reactionSuccess,
-        reactionError,
-        logVerboseMessage,
-        logger,
-        handleMessage,
       });
-    } catch (recoveryErr) {
-      logger?.error?.("zulip recovery: startup failed", {
-        accountId: account.accountId,
-        error: String(recoveryErr),
-      });
+      try {
+        const { recoverInterruptedMessages } = await import("./recovery.js");
+        await recoverInterruptedMessages({
+          client,
+          botEmail,
+          botUserId,
+          botUsername,
+          baseUrl,
+          accountId: account.accountId,
+          reactionStart,
+          reactionSuccess,
+          reactionError,
+          logVerboseMessage,
+          logger,
+          handleMessage,
+        });
+      } catch (recoveryErr) {
+        logger?.error?.("zulip recovery: startup failed", {
+          accountId: account.accountId,
+          error: String(recoveryErr),
+        });
+      }
     }
 
     if (account.streaming === false) {


### PR DESCRIPTION
Closes #254.

## Problem

The ClawHub security scanner flagged the plugin with `scan:suspicious` because the session recovery feature runs automatically on every monitor startup without explicit user opt-in. It scans the last 50 DMs for interrupted messages and re-dispatches them.

## Solution

- Added `enableSessionRecovery: boolean` config option, default `false`
- Only calls `recoverInterruptedMessages` when explicitly enabled
- Logs a startup warning when recovery is enabled
- Wired through config-schema, config-ui-hints, accounts.ts, openclaw.plugin.json

## Files changed

- `src/types.ts` — added `enableSessionRecovery` to `ZulipAccountConfig`
- `src/config-schema.ts` — added to Zod schema
- `src/config-ui-hints.ts` — added UI hint
- `src/zulip/accounts.ts` — resolved and exposed in `ResolvedZulipAccount`
- `src/zulip/monitor.ts` — guarded recovery call behind config flag + startup warning
- `openclaw.plugin.json` — added to JSON schema + UI hints

## Validation

- `npm run check` passes: 207 tests, 0 failures
- TypeScript typecheck passes
- JSON schema is valid