### PR TITLE
fix(skill): add permissions field to SKILL.md frontmatter

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -10,6 +10,14 @@ metadata: {
     }
   }
 }
+permissions:
+  - messaging:send
+  - messaging:receive
+  - streams:read
+  - streams:write
+  - users:read
+  - reactions:manage
+  - files:upload
 ---
 # 💬 Zulip Bridge Skill
 


### PR DESCRIPTION
Resolves Skillspector LP3 finding: "Without declared permissions the skill's intent is opaque and cannot be validated."

Added `permissions` field to SKILL.md frontmatter listing the capabilities this skill requires:
- messaging:send, messaging:receive
- streams:read, streams:write
- users:read
- reactions:manage
- files:upload