### PR TITLE
fix: import formatPairingApproveHint from core subpath (#265)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Calendar Versioning](https://calver.org/) in the format `YYYY.M.PATCH`.
 
+## [2026.8.8] - 2026-08-10
+
+### Fixed
+- **`openclaw doctor --fix` crash** (#265): `formatPairingApproveHint` was imported from `openclaw/plugin-sdk/channel-core`, which does not export it on host 2026.7.x — the import resolved to `undefined` and calling it threw `TypeError: (0, import_channel_core.formatPairingApproveHint) is not a function`. Moved the import to `openclaw/plugin-sdk/core` (where the host SDK actually exports it), matching the existing `normalizeAccountId` import path.
+
+### Changed
+- **Regression guard**: Added `test/sdk-import-paths.test.ts` to statically assert `formatPairingApproveHint` stays on the `core` subpath and that all `channel-core` value imports are host-exported symbols, so a future SDK migration cannot silently reintroduce the wrong import path.
+
 ## [2026.8.4] - 2026-07-27
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OpenClaw Zulip Bridge
 
-[![Version](https://img.shields.io/badge/version-2026.8.7-blue)](https://github.com/niyazmft/openclaw-zulip-bridge/releases)
+[![Version](https://img.shields.io/badge/version-2026.8.8-blue)](https://github.com/niyazmft/openclaw-zulip-bridge/releases)
 [![OpenClaw](https://img.shields.io/badge/OpenClaw-%3E%3D2026.6.0-green)](https://openclaw.ai)
 [![Node.js](https://img.shields.io/badge/Node.js-22%2B-brightgreen)](https://nodejs.org)
 [![pnpm](https://img.shields.io/badge/pnpm-10.32.1-orange)](https://pnpm.io)

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "zulip",
   "name": "Zulip",
   "description": "OpenClaw Zulip channel plugin",
-  "version": "2026.8.7",
+  "version": "2026.8.8",
   "activation": {
     "onStartup": true
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@niyazmft/openclaw-zulip",
-  "version": "2026.8.7",
+  "version": "2026.8.8",
   "description": "OpenClaw Zulip channel plugin",
   "type": "module",
   "packageManager": "pnpm@10.32.1",

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -2,10 +2,9 @@ import {
   createChatChannelPlugin,
   deleteAccountFromConfigSection,
   setAccountEnabledInConfigSection,
-  formatPairingApproveHint,
   type ChannelAccountSnapshot,
 } from "openclaw/plugin-sdk/channel-core";
-import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "openclaw/plugin-sdk/core";
+import { DEFAULT_ACCOUNT_ID, normalizeAccountId, formatPairingApproveHint } from "openclaw/plugin-sdk/core";
 import { setZulipRuntime } from "./runtime.js";
 import type { ZulipConfig } from "./types.js";
 import { zulipMessageActions } from "./actions.js";

--- a/test/sdk-import-paths.test.ts
+++ b/test/sdk-import-paths.test.ts
@@ -1,0 +1,63 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve as pathResolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+// Regression guard for issue #265:
+// `formatPairingApproveHint` is exported from `openclaw/plugin-sdk/core`
+// (and `channel-plugin-common`), but NOT from `openclaw/plugin-sdk/channel-core`.
+// Importing it from `channel-core` resolves to `undefined` at runtime and
+// crashes `openclaw doctor --fix` with
+// "TypeError: (0, import_channel_core.formatPairingApproveHint) is not a function".
+//
+// This test statically checks the source so a future SDK migration cannot
+// silently reintroduce the wrong import path (the local SDK shim fabricates
+// the export, so runtime-style tests would not catch it).
+
+const __dirname = pathResolve(fileURLToPath(import.meta.url), "..");
+const channelSource = readFileSync(pathResolve(__dirname, "../src/channel.ts"), "utf8");
+
+test("formatPairingApproveHint is imported from openclaw/plugin-sdk/core, not channel-core", () => {
+  // The symbol must be imported from the `core` subpath.
+  assert.match(
+    channelSource,
+    /formatPairingApproveHint[^}]*} from "openclaw\/plugin-sdk\/core"/,
+    "formatPairingApproveHint should be imported from openclaw/plugin-sdk/core",
+  );
+  // And it must NOT be imported from channel-core.
+  assert.doesNotMatch(
+    channelSource,
+    /formatPairingApproveHint[\s\S]*?} from "openclaw\/plugin-sdk\/channel-core"/,
+    "formatPairingApproveHint must not be imported from openclaw/plugin-sdk/channel-core",
+  );
+});
+
+test("channel-core import block contains only host-exported symbols", () => {
+  // Symbols the host's channel-core actually exports (verified on 2026.7.1 / 2026.7.1-2).
+  const hostExports = [
+    "createChatChannelPlugin",
+    "deleteAccountFromConfigSection",
+    "setAccountEnabledInConfigSection",
+  ];
+  // formatPairingApproveHint must not appear inside the channel-core import block.
+  const channelCoreBlock = channelSource.match(
+    /import \{([\s\S]*?)\} from "openclaw\/plugin-sdk\/channel-core"/,
+  );
+  assert.ok(channelCoreBlock, "expected a channel-core import block in src/channel.ts");
+  const importedSymbols = channelCoreBlock[1]
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s) => s && !s.startsWith("type "));
+  assert.ok(importedSymbols.length > 0, "expected at least one value import from channel-core");
+  for (const symbol of importedSymbols) {
+    assert.ok(
+      hostExports.includes(symbol),
+      `channel-core import ${symbol} is not exported by the host SDK`,
+    );
+  }
+  assert.ok(
+    !channelCoreBlock[1].includes("formatPairingApproveHint"),
+    "channel-core import block must not contain formatPairingApproveHint",
+  );
+});


### PR DESCRIPTION
Closes #265

## Problem

`openclaw doctor --fix` crashes at the end with:

```
TypeError: (0, import_channel_core.formatPairingApproveHint) is not a function
```

`src/channel.ts` imported `formatPairingApproveHint` from `openclaw/plugin-sdk/channel-core`, but the host SDK does **not** export it from that subpath (verified on host 2026.7.1 container and 2026.7.1-2 y6). The import resolves to `undefined` at runtime, so calling it throws.

The function **is** exported from `openclaw/plugin-sdk/core` (and `channel-plugin-common`) — the plugin already imports `normalizeAccountId` from `core`.

## Changes

- **`src/channel.ts`**: move `formatPairingApproveHint` import from `channel-core` → `core`
- **`test/sdk-import-paths.test.ts`** (new): static regression guard asserting:
  - `formatPairingApproveHint` is imported from `openclaw/plugin-sdk/core`, not `channel-core`
  - every value import in the `channel-core` block is a host-exported symbol
- **Version bump to 2026.8.8**: `package.json`, `openclaw.plugin.json`, README badge, CHANGELOG entry

## Validation

- `npm run check` — 210 tests, 209 pass, 0 fail (incl. 2 new regression tests)
- Verified against real host SDK on y6: `core.formatPairingApproveHint` is a function returning `"Approve via: openclaw pairing list zulip / openclaw pairing approve zulip <code>"`
- Deployed to lab-openclaw container: `openclaw doctor --fix` completes with Plugins `Errors: 0`